### PR TITLE
Docs: add Render deployment URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# handyman (web MVP)
+# HandyBox (web MVP)
+
+## Deployments (Render)
+
+- Web: https://web-e7kl.onrender.com/
+- Storybook: https://storybook-3hlt.onrender.com/
+- API (GraphQL): https://handyman-apollo.onrender.com/graphql
 
 ## Requirements
 
@@ -26,6 +32,13 @@ pnpm storybook
 ```
 
 Then open <http://localhost:6006>.
+
+## Environment
+
+```bash
+# Full GraphQL endpoint (include /graphql)
+NEXT_PUBLIC_GRAPHQL_URL=https://handyman-apollo.onrender.com/graphql
+```
 
 ## Lint / Format
 


### PR DESCRIPTION
Adds the Render deployment URLs + required frontend env var to README.

- Web: https://web-e7kl.onrender.com/
- Storybook: https://storybook-3hlt.onrender.com/
- API (GraphQL): https://handyman-apollo.onrender.com/graphql
