### PR TITLE
Fix UiButton link typing

### DIFF
--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -2,7 +2,9 @@
 
 import { Button, type ButtonProps } from '@chakra-ui/react'
 
-export type UiButtonProps = ButtonProps
+export type UiButtonProps = ButtonProps & {
+  href?: string
+}
 
 export function UiButton(props: UiButtonProps) {
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only change to a UI component’s props with no runtime logic changes; primary risk is minor type incompatibility for callers relying on stricter props.
> 
> **Overview**
> `UiButton` now extends Chakra `ButtonProps` with an optional `href` field, fixing TypeScript typing when the button is used as a link (e.g., via `as={NextLink}`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77adcb9e216f1a87428c3373496483b670a026c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->