### PR TITLE
fix: align tasks query with backend args contract

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -73,7 +73,7 @@ type Job {
 type Query {
   health: String!
   me: User
-  tasks(limit: Int, offset: Int): [Task!]!
+  tasks: [Task!]!
   task(id: ID!): Task
   job(id: ID!): Job
   myJobs: [Job!]!

--- a/src/app/components/TaskBoard.tsx
+++ b/src/app/components/TaskBoard.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react'
 import { TASKS_QUERY } from '@/graphql/jobs'
 import { Badge } from '@/ui/Badge/Badge'
 import { Button } from '@/ui/Button/Button'
-import type { TasksQuery, TasksQueryVariables } from '@codegen/schema'
+import type { TasksQuery } from '@codegen/schema'
 import { GlassCard } from '../../ui/Card/GlassCard'
 
 export type TaskBoardProps = {
@@ -29,19 +29,13 @@ function formatBudget(offers: { pricePence: number }[]) {
 export function TaskBoard({ title = 'Latest tasks' }: TaskBoardProps) {
   const [page, setPage] = useState(0)
   const offset = page * PAGE_SIZE
-  const { data, loading, error } = useQuery<TasksQuery, TasksQueryVariables>(
-    TASKS_QUERY,
-    {
-      variables: {
-        limit: PAGE_SIZE,
-        offset,
-      },
-      notifyOnNetworkStatusChange: true,
-    },
-  )
-  const tasks = data?.tasks ?? []
+  const { data, loading, error } = useQuery<TasksQuery>(TASKS_QUERY, {
+    notifyOnNetworkStatusChange: true,
+  })
+  const allTasks = data?.tasks ?? []
+  const tasks = allTasks.slice(offset, offset + PAGE_SIZE)
   const hasPreviousPage = page > 0
-  const hasNextPage = tasks.length === PAGE_SIZE
+  const hasNextPage = offset + PAGE_SIZE < allTasks.length
 
   return (
     <GlassCard p={6}>

--- a/src/app/components/TaskBoard.tsx
+++ b/src/app/components/TaskBoard.tsx
@@ -121,7 +121,9 @@ export function TaskBoard({ title = 'Latest tasks' }: TaskBoardProps) {
                 variant="outline"
                 borderColor="border"
                 disabled={!hasPreviousPage || loading}
-                onClick={() => setPage((currentPage) => Math.max(currentPage - 1, 0))}
+                onClick={() =>
+                  setPage((currentPage) => Math.max(currentPage - 1, 0))
+                }
               >
                 Previous
               </Button>

--- a/src/graphql/jobs.ts
+++ b/src/graphql/jobs.ts
@@ -22,8 +22,8 @@ export const ADD_OFFER = gql`
 `
 
 export const TASKS_QUERY = gql`
-  query Tasks($limit: Int, $offset: Int) {
-    tasks(limit: $limit, offset: $offset) {
+  query Tasks {
+    tasks {
       id
       title
       description


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove `limit`/`offset` arguments from `TASKS_QUERY` to match the live backend schema for `Query.tasks`
- keep UI pagination in `TaskBoard` by slicing the fetched task list on the client
- update checked-in GraphQL schema so `tasks` has no arguments

## Root cause
The frontend query and checked-in schema expected `Query.tasks(limit, offset)`, but the live backend currently exposes `Query.tasks` without those arguments. This caused runtime GraphQL validation failures:
- `Unknown argument "limit" on field "Query.tasks"`
- `Unknown argument "offset" on field "Query.tasks"`

## Testing
- `bun run lint`
- `bun run build`
- manual browser verification on `/` and `/tasks` (no `Unknown argument` error displayed, tasks load successfully)
- direct API validation with curl:
  - query with args returns GraphQL validation error
  - query without args returns task data

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-9](https://linear.app/handybox/issue/FE-9/bug-fix-unknown-argument-offset-on-field-querytasks)

<div><a href="https://cursor.com/agents/bc-ac2c4743-5da0-46ed-b417-dd91072cb16f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac2c4743-5da0-46ed-b417-dd91072cb16f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

