### PR TITLE
FE-15: Refactor task detail page with new job hub UI

### DIFF
--- a/src/app/task/[slug]/page.tsx
+++ b/src/app/task/[slug]/page.tsx
@@ -1,14 +1,17 @@
 'use client'
 
-import { Box, HStack, Link, Stack } from '@chakra-ui/react'
+import { useMutation, useQuery } from '@apollo/client/react'
+import { Box, Grid, HStack, Link, Stack, VStack } from '@chakra-ui/react'
+import type { AddOfferMutation, MeQuery, TaskQuery } from '@codegen/schema'
 import NextLink from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
 
-import { ADD_OFFER, TASK_QUERY } from '@/graphql/jobs'
+import { ME_QUERY } from '@/graphql/auth'
+import { ACCEPT_OFFER_MUTATION, ADD_OFFER, TASK_QUERY } from '@/graphql/jobs'
 import { getAuthToken } from '@/utils/auth'
+import { formatRelativeTime } from '@/utils/formatRelativeTime'
 import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
-import { useMutation, useQuery } from '@apollo/client/react'
-import type { AddOfferMutation, TaskQuery } from '@codegen/schema'
 import {
   Badge,
   Button,
@@ -16,11 +19,23 @@ import {
   GlassCard,
   Header,
   Heading,
+  IconCalendar,
+  IconDocument,
+  IconMapPin,
+  IconWrench,
   Section,
+  TaskOfferCard,
   Text,
   TextInput,
 } from '@ui'
-import { useState } from 'react'
+
+type AcceptOfferMutationData = {
+  acceptOffer?: {
+    id: string
+    status: string
+    selectedOfferId?: string | null
+  } | null
+}
 
 function formatDateTime(isoDateTime: string) {
   return new Intl.DateTimeFormat('en-GB', {
@@ -29,9 +44,70 @@ function formatDateTime(isoDateTime: string) {
   }).format(new Date(isoDateTime))
 }
 
+function formatTimelineStamp(iso: unknown) {
+  const d =
+    typeof iso === 'string' || typeof iso === 'number'
+      ? new Date(iso)
+      : iso instanceof Date
+        ? iso
+        : null
+  if (!d || Number.isNaN(d.getTime())) return '—'
+  const now = new Date()
+  const isSameDay =
+    d.getDate() === now.getDate() &&
+    d.getMonth() === now.getMonth() &&
+    d.getFullYear() === now.getFullYear()
+  const time = new Intl.DateTimeFormat('en-GB', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(d)
+  if (isSameDay) return `Today at ${time}`
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(d)
+}
+
 function formatPaymentMethod(paymentMethod: string) {
   const normalised = paymentMethod.replaceAll('_', ' ').toLowerCase()
   return normalised.charAt(0).toUpperCase() + normalised.slice(1)
+}
+
+function formatPounds(pricePence: number) {
+  return `£${(pricePence / 100).toFixed(0)}`
+}
+
+function normaliseStatus(status: string) {
+  return status.replaceAll('_', ' ').toUpperCase()
+}
+
+function statusBannerLabel(status: string, offerCount: number) {
+  const s = status.toUpperCase()
+  if (s === 'OPEN' || s === 'POSTED' || s === 'PUBLISHED') {
+    const n = offerCount
+    return `OPEN — ${n} OFFER${n === 1 ? '' : 'S'} RECEIVED`
+  }
+  return normaliseStatus(status)
+}
+
+function workerAvatarLabel(workerUserId: string) {
+  const alnum = workerUserId.replace(/[^a-zA-Z0-9]/g, '')
+  if (alnum.length >= 2) return alnum.slice(0, 2)
+  if (alnum.length === 1) return `${alnum}P`
+  return 'PR'
+}
+
+function categoryGradient(category: string): string {
+  const key = category.toLowerCase()
+  if (key.includes('plumb'))
+    return 'linear-gradient(135deg, #1A56DB 0%, #003fb1 100%)'
+  if (key.includes('electr'))
+    return 'linear-gradient(135deg, #5f88e8 0%, #1A56DB 100%)'
+  if (key.includes('carpent') || key.includes('wood'))
+    return 'linear-gradient(135deg, #cb7f08 0%, #855300 100%)'
+  if (key.includes('hvac') || key.includes('heat'))
+    return 'linear-gradient(135deg, #059669 0%, #047857 100%)'
+  return 'linear-gradient(135deg, #dfe8f7 0%, #b5ceff 100%)'
 }
 
 export default function TaskDetailPage() {
@@ -44,15 +120,46 @@ export default function TaskDetailPage() {
   const [message, setMessage] = useState('')
   const [offerError, setOfferError] = useState<string | null>(null)
   const [offerSuccess, setOfferSuccess] = useState<string | null>(null)
+  const [acceptError, setAcceptError] = useState<string | null>(null)
+  const [acceptingOfferId, setAcceptingOfferId] = useState<string | null>(null)
 
-  const { data, loading, error } = useQuery<TaskQuery>(TASK_QUERY, {
+  const hasToken = typeof window !== 'undefined' && Boolean(getAuthToken())
+
+  const { data: meData } = useQuery<MeQuery>(ME_QUERY, {
+    skip: !hasToken,
+    fetchPolicy: 'cache-first',
+  })
+  const me = meData?.me ?? null
+
+  const { data, loading, error, refetch } = useQuery<TaskQuery>(TASK_QUERY, {
     variables: { id: taskId },
     skip: !taskId,
   })
+
   const [addOffer, { loading: quoting }] =
     useMutation<AddOfferMutation>(ADD_OFFER)
 
+  const [acceptOffer] = useMutation<AcceptOfferMutationData>(
+    ACCEPT_OFFER_MUTATION,
+  )
+
   const task = data?.task
+
+  const isOwner = Boolean(me && task && me.id === task.createdByUserId)
+  const myOffer = useMemo(() => {
+    if (!me || !task) return null
+    return task.offers.find((o) => o.workerUserId === me.id) ?? null
+  }, [me, task])
+
+  const sortedOffers = useMemo(() => {
+    if (!task) return []
+    return [...task.offers].sort((a, b) => a.pricePence - b.pricePence)
+  }, [task])
+
+  const lowestPricePence = useMemo(() => {
+    if (sortedOffers.length === 0) return null
+    return sortedOffers[0]?.pricePence ?? null
+  }, [sortedOffers])
 
   async function onSubmitOffer() {
     setOfferError(null)
@@ -83,10 +190,37 @@ export default function TaskDetailPage() {
         throw new Error('Offer submission failed. Please try again.')
       }
       setOfferSuccess('Offer submitted successfully.')
+      void refetch()
     } catch (err: unknown) {
       setOfferError(getFriendlyErrorMessage(err, 'Offer submission failed.'))
     }
   }
+
+  async function onAcceptOffer(offerId: string) {
+    if (!task) return
+    setAcceptError(null)
+    setAcceptingOfferId(offerId)
+    try {
+      const res = await acceptOffer({
+        variables: { offerId },
+      })
+      if (!res.data?.acceptOffer?.id) {
+        throw new Error('Could not accept this offer.')
+      }
+      await refetch()
+    } catch (err: unknown) {
+      setAcceptError(
+        getFriendlyErrorMessage(err, 'Could not accept this offer.'),
+      )
+    } finally {
+      setAcceptingOfferId(null)
+    }
+  }
+
+  const canAcceptOffers =
+    isOwner &&
+    task &&
+    ['OPEN', 'POSTED', 'PUBLISHED'].includes(task.status.toUpperCase())
 
   if (!taskId) {
     return (
@@ -103,7 +237,7 @@ export default function TaskDetailPage() {
               color="primary.700"
               _hover={{ textDecoration: 'none' }}
             >
-              ← Back to tasks
+              ← Back to Job Board
             </Link>
             <Text color="muted">No task ID provided.</Text>
           </Section>
@@ -119,159 +253,486 @@ export default function TaskDetailPage() {
         <Section id="header" py={{ base: 6, md: 8 }}>
           <Header activeItem="tasks" />
         </Section>
-        <Section>
-          <Stack gap={10}>
-            <Stack gap={4}>
-              <Link
-                as={NextLink}
-                href="/tasks"
-                fontWeight={600}
-                color="primary.700"
-                _hover={{ textDecoration: 'none' }}
-              >
-                ← Back to tasks
-              </Link>
+        <Box as="section" py={{ base: 8, md: 10 }}>
+          <Box maxW="7xl" mx="auto" px={{ base: 4, md: 6 }}>
+            <Stack gap={10}>
+              <Stack gap={4}>
+                <Link
+                  as={NextLink}
+                  href="/tasks"
+                  fontWeight={600}
+                  fontSize="sm"
+                  color="primary.600"
+                  _hover={{ color: 'primary.700', textDecoration: 'none' }}
+                >
+                  ← Back to Job Board
+                </Link>
 
-              {loading ? (
-                <Text color="muted">Loading task…</Text>
-              ) : error ? (
-                <Text color="red.400" fontSize="sm">
-                  {error.message}
-                </Text>
-              ) : !task ? (
-                <Text color="muted">Task not found.</Text>
-              ) : (
-                <>
-                  <Stack gap={3}>
-                    <HStack justify="space-between" flexWrap="wrap" gap={3}>
-                      <Heading size="lg">{task.title}</Heading>
-                      {task.offers.length > 0 && (
-                        <Badge px={2}>
-                          £
-                          {(
-                            Math.min(...task.offers.map((o) => o.pricePence)) /
-                            100
-                          ).toFixed(0)}
-                          –£
-                          {(
-                            Math.max(...task.offers.map((o) => o.pricePence)) /
-                            100
-                          ).toFixed(0)}
-                        </Badge>
-                      )}
-                    </HStack>
-                    <Text color="muted">{task.description}</Text>
-                    <HStack gap={2} flexWrap="wrap">
-                      {task.location ? (
-                        <Badge bg="surfaceContainerLow" color="fg">
-                          {task.location}
-                        </Badge>
-                      ) : null}
-                      {task.category ? (
-                        <Badge bg="surfaceContainerLow" color="fg">
-                          {task.category}
-                        </Badge>
-                      ) : null}
-                      {task.priceOfferPence ? (
-                        <Badge px={2}>
-                          £{(task.priceOfferPence / 100).toFixed(0)}
-                        </Badge>
-                      ) : null}
-                    </HStack>
-                  </Stack>
-
-                  <GlassCard p={6}>
-                    <Stack gap={4}>
-                      <Heading size="md">Task details</Heading>
-                      <Text color="muted">{task.description}</Text>
-                      <Stack gap={2} fontSize="sm">
-                        {task.location && (
-                          <Text>
-                            <strong>Location:</strong> {task.location}
-                          </Text>
-                        )}
-                        {task.dateTime && (
-                          <Text>
-                            <strong>Date & time:</strong>{' '}
-                            {formatDateTime(task.dateTime)}
-                          </Text>
-                        )}
-                        {task.category && (
-                          <Text>
-                            <strong>Category:</strong> {task.category}
-                          </Text>
-                        )}
-                        {task.priceOfferPence && (
-                          <Text>
-                            <strong>Expected price:</strong> £
-                            {(task.priceOfferPence / 100).toFixed(0)}
-                          </Text>
-                        )}
-                        {task.paymentMethod && (
-                          <Text>
-                            <strong>Payment method:</strong>{' '}
-                            {formatPaymentMethod(task.paymentMethod)}
-                          </Text>
-                        )}
-                        {task.contactMethod && (
-                          <Text>
-                            <strong>Contact method:</strong>{' '}
-                            {task.contactMethod}
-                          </Text>
-                        )}
-                        {task.offers.length > 0 && (
-                          <Text>
-                            <strong>Offers:</strong> {task.offers.length}{' '}
-                            received
-                          </Text>
-                        )}
-                      </Stack>
-                    </Stack>
-                  </GlassCard>
-
-                  <GlassCard p={6} id="offer">
-                    <Stack gap={4}>
-                      <Heading size="md">Make an offer</Heading>
-                      <Text color="muted">
-                        Share your price and any message for the client.
-                      </Text>
-                      <Stack gap={3}>
-                        <TextInput
-                          placeholder="Offer price (pence)"
-                          value={pricePence}
-                          onChange={(e) => setPricePence(e.target.value)}
-                        />
-                        <TextInput
-                          placeholder="Short message to the client"
-                          value={message}
-                          onChange={(e) => setMessage(e.target.value)}
-                        />
-                        <Button
-                          background="linkBlue.600"
+                {loading ? (
+                  <Text color="muted">Loading task…</Text>
+                ) : error ? (
+                  <Text color="red.400" fontSize="sm">
+                    {error.message}
+                  </Text>
+                ) : !task ? (
+                  <Text color="muted">Task not found.</Text>
+                ) : (
+                  <Grid
+                    templateColumns={{
+                      base: '1fr',
+                      xl: 'minmax(0, 1fr) 400px',
+                    }}
+                    gap={{ base: 10, xl: 10 }}
+                    alignItems="flex-start"
+                  >
+                    <Stack gap={8}>
+                      <Stack gap={4}>
+                        <Box
+                          as="span"
+                          display="inline-flex"
+                          alignSelf="flex-start"
+                          alignItems="center"
+                          gap={2}
+                          px={4}
+                          py={1.5}
+                          borderRadius="full"
+                          bg="#F2994A"
                           color="white"
-                          loading={quoting}
-                          onClick={() => void onSubmitOffer()}
+                          fontSize="11px"
+                          fontWeight={800}
+                          letterSpacing="0.08em"
                         >
-                          Submit offer
-                        </Button>
-                        {offerError ? (
-                          <Text color="red.400" fontSize="sm">
-                            {offerError}
-                          </Text>
-                        ) : null}
-                        {offerSuccess ? (
-                          <Text color="green.400" fontSize="sm">
-                            {offerSuccess}
-                          </Text>
-                        ) : null}
+                          <Box
+                            as="span"
+                            w="6px"
+                            h="6px"
+                            borderRadius="full"
+                            bg="white"
+                            aria-hidden
+                          />
+                          {statusBannerLabel(task.status, task.offers.length)}
+                        </Box>
+                        <Heading
+                          size="xl"
+                          color="ink.900"
+                          lineHeight="shorter"
+                          fontWeight={800}
+                        >
+                          {task.title}
+                        </Heading>
+                        <HStack gap={{ base: 4, md: 8 }} flexWrap="wrap">
+                          <HStack gap={2} color="muted">
+                            <IconWrench />
+                            <Text fontSize="sm" fontWeight={600} color="fg">
+                              {task.category?.trim() || 'General'}
+                            </Text>
+                          </HStack>
+                          {task.location ? (
+                            <HStack gap={2} color="muted">
+                              <IconMapPin />
+                              <Text fontSize="sm" fontWeight={600} color="fg">
+                                {task.location}
+                              </Text>
+                            </HStack>
+                          ) : null}
+                          <HStack gap={2} color="muted">
+                            <IconCalendar />
+                            <Text fontSize="sm" fontWeight={600} color="fg">
+                              {formatRelativeTime(task.createdAt)}
+                            </Text>
+                          </HStack>
+                        </HStack>
                       </Stack>
+
+                      <GlassCard p={{ base: 5, md: 6 }} borderColor="border">
+                        <Stack gap={4}>
+                          <HStack gap={2}>
+                            <IconDocument color="primary.600" />
+                            <Heading size="md">Job description</Heading>
+                          </HStack>
+                          <Text color="muted" lineHeight="tall">
+                            {task.description}
+                          </Text>
+                          <Grid
+                            templateColumns={{
+                              base: '1fr',
+                              sm: 'repeat(2, minmax(0, 1fr))',
+                            }}
+                            gap={3}
+                          >
+                            {task.dateTime ? (
+                              <Box
+                                borderRadius="lg"
+                                bg="primary.50"
+                                px={4}
+                                py={3}
+                                borderWidth="1px"
+                                borderColor="primary.100"
+                              >
+                                <Text
+                                  fontSize="10px"
+                                  fontWeight={800}
+                                  letterSpacing="0.1em"
+                                  color="primary.700"
+                                  mb={1}
+                                >
+                                  PREFERRED WINDOW
+                                </Text>
+                                <Text fontWeight={700} color="fg">
+                                  {formatDateTime(task.dateTime)}
+                                </Text>
+                              </Box>
+                            ) : null}
+                            {task.priceOfferPence != null &&
+                            task.priceOfferPence > 0 ? (
+                              <Box
+                                borderRadius="lg"
+                                bg="primary.50"
+                                px={4}
+                                py={3}
+                                borderWidth="1px"
+                                borderColor="primary.100"
+                              >
+                                <Text
+                                  fontSize="10px"
+                                  fontWeight={800}
+                                  letterSpacing="0.1em"
+                                  color="primary.700"
+                                  mb={1}
+                                >
+                                  CLIENT BUDGET
+                                </Text>
+                                <Text fontWeight={700} color="fg">
+                                  {formatPounds(task.priceOfferPence)}
+                                </Text>
+                              </Box>
+                            ) : null}
+                          </Grid>
+                          <Stack
+                            gap={2}
+                            fontSize="sm"
+                            pt={2}
+                            borderTopWidth="1px"
+                            borderColor="border"
+                          >
+                            {task.paymentMethod ? (
+                              <Text color="muted">
+                                <Text as="span" fontWeight={600} color="fg">
+                                  Payment:{' '}
+                                </Text>
+                                {formatPaymentMethod(task.paymentMethod)}
+                              </Text>
+                            ) : null}
+                            {task.contactMethod ? (
+                              <Text color="muted">
+                                <Text as="span" fontWeight={600} color="fg">
+                                  Contact:{' '}
+                                </Text>
+                                {task.contactMethod}
+                              </Text>
+                            ) : null}
+                          </Stack>
+                        </Stack>
+                      </GlassCard>
+
+                      <Stack gap={3}>
+                        <Heading size="md">Job photos</Heading>
+                        <Grid
+                          templateColumns={{ base: '1fr', md: '1.4fr 1fr' }}
+                          templateRows={{
+                            base: 'repeat(3, minmax(120px, 160px))',
+                            md: 'repeat(2, minmax(100px, 140px))',
+                          }}
+                          gap={3}
+                        >
+                          <Box
+                            gridRow={{ base: 'auto', md: '1 / -1' }}
+                            borderRadius="xl"
+                            minH={{ base: '160px', md: 'auto' }}
+                            bg={categoryGradient(
+                              task.category?.trim() || 'General',
+                            )}
+                            opacity={0.85}
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            color="white"
+                            fontWeight={800}
+                            fontSize="sm"
+                            letterSpacing="0.06em"
+                            textAlign="center"
+                            px={4}
+                          >
+                            Photo preview unavailable for this job
+                          </Box>
+                          <Box
+                            borderRadius="xl"
+                            bg="surfaceContainerLow"
+                            borderWidth="1px"
+                            borderColor="border"
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            color="muted"
+                            fontSize="sm"
+                            fontWeight={600}
+                          >
+                            Attachments are not shown on the web yet
+                          </Box>
+                          <Box
+                            borderRadius="xl"
+                            bg="surfaceContainerHigh"
+                            borderWidth="1px"
+                            borderColor="border"
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            color="muted"
+                            fontSize="sm"
+                            fontWeight={600}
+                          >
+                            More photos on mobile soon
+                          </Box>
+                        </Grid>
+                      </Stack>
+
+                      <Box
+                        borderRadius="xl"
+                        bg="surfaceContainerLow"
+                        px={{ base: 5, md: 6 }}
+                        py={5}
+                        borderWidth="1px"
+                        borderColor="border"
+                      >
+                        <Heading size="md" mb={5}>
+                          Job timeline
+                        </Heading>
+                        <Stack gap={0} position="relative">
+                          <HStack align="flex-start" gap={4} pb={6}>
+                            <VStack gap={0} flexShrink={0} align="center">
+                              <Box
+                                boxSize="36px"
+                                borderRadius="full"
+                                bg="primary.600"
+                                color="white"
+                                display="flex"
+                                alignItems="center"
+                                justifyContent="center"
+                                fontSize="sm"
+                                fontWeight={800}
+                              >
+                                ✓
+                              </Box>
+                              <Box
+                                flex={1}
+                                w="2px"
+                                minH="32px"
+                                bg={
+                                  task.offers.length > 0
+                                    ? '#F2994A'
+                                    : 'outlineVariant'
+                                }
+                                borderRadius="full"
+                                mt={1}
+                              />
+                            </VStack>
+                            <Stack gap={0.5} pt={1}>
+                              <Text fontWeight={700}>Job posted</Text>
+                              <Text fontSize="sm" color="muted">
+                                {formatTimelineStamp(task.createdAt)}
+                              </Text>
+                            </Stack>
+                          </HStack>
+                          <HStack align="flex-start" gap={4}>
+                            <Box
+                              flexShrink={0}
+                              boxSize="36px"
+                              borderRadius="full"
+                              bg="#F2994A"
+                              color="white"
+                              display="flex"
+                              alignItems="center"
+                              justifyContent="center"
+                              aria-hidden
+                            >
+                              <svg
+                                viewBox="0 0 24 24"
+                                width="18"
+                                height="18"
+                                fill="none"
+                                aria-hidden
+                              >
+                                <path
+                                  d="M7 18.5 3 21v-3.5A4 4 0 0 1 5 9a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4 4 4 0 0 1-4 4H9l-2 1.5Z"
+                                  stroke="currentColor"
+                                  strokeWidth="1.75"
+                                  strokeLinejoin="round"
+                                />
+                              </svg>
+                            </Box>
+                            <Stack gap={0.5} pt={1}>
+                              <Text fontWeight={700}>
+                                {task.offers.length > 0
+                                  ? 'Reviewing offers'
+                                  : 'Waiting for offers'}
+                              </Text>
+                              <Text fontSize="sm" color="muted">
+                                {task.offers.length > 0
+                                  ? `${task.offers.length} professional${task.offers.length === 1 ? '' : 's'} interested`
+                                  : 'Share this job to attract quotes faster.'}
+                              </Text>
+                            </Stack>
+                          </HStack>
+                        </Stack>
+                      </Box>
+
+                      {!isOwner ? (
+                        <Stack gap={6} id="offer">
+                          {myOffer ? (
+                            <GlassCard p={6}>
+                              <Stack gap={3}>
+                                <Heading size="md">Your offer</Heading>
+                                <Text color="muted">
+                                  You submitted{' '}
+                                  {formatPounds(myOffer.pricePence)}
+                                  {myOffer.message
+                                    ? ` — “${myOffer.message}”`
+                                    : '.'}
+                                </Text>
+                                <Badge
+                                  bg="surfaceContainerLow"
+                                  color="fg"
+                                  w="fit-content"
+                                >
+                                  Status: {normaliseStatus(myOffer.status)}
+                                </Badge>
+                              </Stack>
+                            </GlassCard>
+                          ) : (
+                            <GlassCard p={6}>
+                              <Stack gap={4}>
+                                <Heading size="md">Make an offer</Heading>
+                                <Text color="muted">
+                                  Share your price and any message for the
+                                  client.
+                                </Text>
+                                <Stack gap={3}>
+                                  <TextInput
+                                    placeholder="Offer price (pence)"
+                                    value={pricePence}
+                                    onChange={(e) =>
+                                      setPricePence(e.target.value)
+                                    }
+                                  />
+                                  <TextInput
+                                    placeholder="Short message to the client"
+                                    value={message}
+                                    onChange={(e) => setMessage(e.target.value)}
+                                  />
+                                  <Button
+                                    background="linkBlue.600"
+                                    color="white"
+                                    loading={quoting}
+                                    onClick={() => void onSubmitOffer()}
+                                  >
+                                    Submit offer
+                                  </Button>
+                                  {offerError ? (
+                                    <Text color="red.400" fontSize="sm">
+                                      {offerError}
+                                    </Text>
+                                  ) : null}
+                                  {offerSuccess ? (
+                                    <Text color="green.600" fontSize="sm">
+                                      {offerSuccess}
+                                    </Text>
+                                  ) : null}
+                                </Stack>
+                              </Stack>
+                            </GlassCard>
+                          )}
+                        </Stack>
+                      ) : null}
                     </Stack>
-                  </GlassCard>
-                </>
-              )}
+
+                    {isOwner ? (
+                      <Box
+                        position={{ base: 'static', xl: 'sticky' }}
+                        top={{ xl: '88px' }}
+                        w="full"
+                      >
+                        <Stack gap={4} id="offers">
+                          <HStack justify="space-between" align="center">
+                            <Heading size="md">
+                              Offers ({task.offers.length})
+                            </Heading>
+                            {task.offers.length > 3 ? (
+                              <Link
+                                as={NextLink}
+                                href="#offers-list"
+                                fontSize="sm"
+                                fontWeight={700}
+                                color="primary.600"
+                                _hover={{ color: 'primary.700' }}
+                              >
+                                View all
+                              </Link>
+                            ) : null}
+                          </HStack>
+                          {acceptError ? (
+                            <Text color="red.400" fontSize="sm">
+                              {acceptError}
+                            </Text>
+                          ) : null}
+                          {task.offers.length === 0 ? (
+                            <GlassCard p={6}>
+                              <Text color="muted">
+                                No offers yet. Share your job link to get quotes
+                                from professionals.
+                              </Text>
+                            </GlassCard>
+                          ) : (
+                            <Stack
+                              gap={4}
+                              id="offers-list"
+                              maxH={{ xl: 'calc(100vh - 140px)' }}
+                              overflowY={{ xl: 'auto' }}
+                              pr={{ xl: 1 }}
+                              style={{ scrollbarGutter: 'stable' }}
+                            >
+                              {sortedOffers.map((offer) => (
+                                <TaskOfferCard
+                                  key={offer.id}
+                                  name="Professional"
+                                  avatarLabel={workerAvatarLabel(
+                                    offer.workerUserId,
+                                  )}
+                                  priceLabel={formatPounds(offer.pricePence)}
+                                  message={offer.message}
+                                  acceptPrimary={
+                                    offer.pricePence === lowestPricePence
+                                  }
+                                  messageHref="/dashboard"
+                                  isOwnOffer={false}
+                                  onAccept={
+                                    canAcceptOffers
+                                      ? () => void onAcceptOffer(offer.id)
+                                      : undefined
+                                  }
+                                  acceptLoading={acceptingOfferId === offer.id}
+                                />
+                              ))}
+                            </Stack>
+                          )}
+                        </Stack>
+                      </Box>
+                    ) : null}
+                  </Grid>
+                )}
+              </Stack>
             </Stack>
-          </Stack>
-        </Section>
+          </Box>
+        </Box>
         <Footer />
       </Stack>
     </Box>

--- a/src/ui/TaskBrowse/TaskBrowseMetaIcons.tsx
+++ b/src/ui/TaskBrowse/TaskBrowseMetaIcons.tsx
@@ -91,3 +91,50 @@ export function IconSliders(props: BoxProps) {
     </Box>
   )
 }
+
+export function IconCalendar(props: BoxProps) {
+  return (
+    <Box as="span" w="16px" h="16px" {...iconWrap} {...props}>
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Posted date</title>
+        <rect
+          x="3.5"
+          y="5.5"
+          width="17"
+          height="15"
+          rx="2.5"
+          stroke="currentColor"
+          strokeWidth="1.75"
+        />
+        <path
+          d="M8 3.5v4M16 3.5v4M3.5 10.5h17"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+      </svg>
+    </Box>
+  )
+}
+
+export function IconDocument(props: BoxProps) {
+  return (
+    <Box as="span" w="18px" h="18px" {...iconWrap} {...props}>
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Job description</title>
+        <path
+          d="M14.5 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7.5L14.5 2Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M14 2v6h6M9 13h6M9 17h4"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+      </svg>
+    </Box>
+  )
+}

--- a/src/ui/TaskOfferCard/TaskOfferCard.stories.tsx
+++ b/src/ui/TaskOfferCard/TaskOfferCard.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { TaskOfferCard } from './TaskOfferCard'
+
+const meta = {
+  title: 'ui/TaskOfferCard',
+  component: TaskOfferCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    name: 'Mike R.',
+    avatarLabel: 'MR',
+    priceLabel: '£120',
+    message: 'Available tomorrow morning and can bring parts if needed.',
+    ratingSummary: '4.9 (124 reviews)',
+    trustBadge: 'pro',
+    acceptPrimary: true,
+    messageHref: '/dashboard',
+    isOwnOffer: false,
+    acceptLoading: false,
+    acceptDisabled: false,
+  },
+} satisfies Meta<typeof TaskOfferCard>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const VerifiedSecondary: Story = {
+  args: {
+    name: 'Sarah Chen',
+    avatarLabel: 'SC',
+    priceLabel: '£95',
+    trustBadge: 'verified',
+    acceptPrimary: false,
+    ratingSummary: '4.8 (56 reviews)',
+  },
+}
+
+export const OwnOffer: Story = {
+  args: {
+    isOwnOffer: true,
+    acceptPrimary: false,
+  },
+}

--- a/src/ui/TaskOfferCard/TaskOfferCard.tsx
+++ b/src/ui/TaskOfferCard/TaskOfferCard.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { Box, HStack, Stack } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+import { Badge } from '../Badge'
+import { Button } from '../Button'
+import { Heading, Text } from '../Typography'
+
+export type TaskOfferCardProps = {
+  name: string
+  avatarLabel: string
+  priceLabel: string
+  message?: string | null
+  ratingSummary?: string | null
+  trustBadge?: 'pro' | 'verified'
+  acceptPrimary?: boolean
+  messageHref: string
+  isOwnOffer?: boolean
+  onAccept?: () => void
+  acceptLoading?: boolean
+  acceptDisabled?: boolean
+}
+
+function avatarGradient(seed: string): string {
+  let h = 0
+  for (let i = 0; i < seed.length; i += 1) {
+    h = (h * 31 + seed.charCodeAt(i)) >>> 0
+  }
+  const hue = h % 360
+  return `linear-gradient(135deg, hsl(${hue} 55% 42%) 0%, hsl(${(hue + 40) % 360} 60% 36%) 100%)`
+}
+
+export function TaskOfferCard({
+  name,
+  avatarLabel,
+  priceLabel,
+  message,
+  ratingSummary,
+  trustBadge,
+  acceptPrimary = false,
+  messageHref,
+  isOwnOffer = false,
+  onAccept,
+  acceptLoading = false,
+  acceptDisabled = false,
+}: TaskOfferCardProps) {
+  const snippet =
+    message && message.trim().length > 0
+      ? message.length > 140
+        ? `${message.slice(0, 137).trim()}…`
+        : message
+      : 'No message provided with this quote.'
+
+  return (
+    <Stack
+      gap={3}
+      p={4}
+      borderRadius="xl"
+      bg="surfaceContainerLowest"
+      borderWidth="1px"
+      borderColor="border"
+      boxShadow="ghostBorder"
+    >
+      <HStack align="flex-start" gap={3}>
+        <Box
+          flexShrink={0}
+          boxSize="52px"
+          borderRadius="lg"
+          bg={avatarGradient(name + avatarLabel)}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          color="white"
+          fontWeight={800}
+          fontSize="sm"
+          letterSpacing="0.02em"
+        >
+          {avatarLabel.slice(0, 2).toUpperCase()}
+        </Box>
+        <Stack gap={1} flex={1} minW={0}>
+          <HStack justify="space-between" align="flex-start" gap={2}>
+            <HStack gap={2} flexWrap="wrap" align="center">
+              <Heading size="sm" lineHeight="short">
+                {name}
+              </Heading>
+              {trustBadge === 'pro' ? (
+                <Badge
+                  px={2}
+                  py={0.5}
+                  fontSize="10px"
+                  bg="primary.100"
+                  color="primary.700"
+                >
+                  PRO
+                </Badge>
+              ) : null}
+              {trustBadge === 'verified' ? (
+                <Text fontSize="xs" fontWeight={600} color="primary.600">
+                  ✓ Verified
+                </Text>
+              ) : null}
+            </HStack>
+            <Text fontWeight={800} fontSize="lg" color="fg" flexShrink={0}>
+              {priceLabel}
+            </Text>
+          </HStack>
+          {ratingSummary ? (
+            <Text fontSize="sm" color="secondary.500" fontWeight={600}>
+              ★ {ratingSummary}
+            </Text>
+          ) : null}
+        </Stack>
+      </HStack>
+      <Text fontSize="sm" color="muted" fontStyle="italic" lineHeight="tall">
+        “{snippet}”
+      </Text>
+      <HStack gap={2} flexWrap="wrap">
+        <Button
+          as={NextLink}
+          href={messageHref}
+          size="sm"
+          variant="outline"
+          borderColor="primary.200"
+          color="primary.700"
+          bg="primary.50"
+          px={4}
+          flex={1}
+          minW="120px"
+        >
+          Message
+        </Button>
+        {isOwnOffer ? (
+          <Button
+            size="sm"
+            variant="outline"
+            borderColor="border"
+            color="muted"
+            flex={1}
+            minW="120px"
+            disabled
+          >
+            Your offer
+          </Button>
+        ) : onAccept ? (
+          <Button
+            size="sm"
+            px={4}
+            flex={1}
+            minW="120px"
+            loading={acceptLoading}
+            disabled={acceptDisabled}
+            onClick={onAccept}
+            {...(acceptPrimary
+              ? {}
+              : {
+                  variant: 'outline' as const,
+                  borderColor: 'primary.200',
+                  color: 'primary.700',
+                  bg: 'primary.50',
+                })}
+          >
+            Accept offer
+          </Button>
+        ) : null}
+      </HStack>
+    </Stack>
+  )
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -11,7 +11,9 @@ export { Container } from './Container'
 export { FormField } from './FormField/FormField'
 export { GlassCard } from './Card/GlassCard'
 export {
+  IconCalendar,
   IconClock,
+  IconDocument,
   IconMapPin,
   IconSliders,
   IconWrench,
@@ -19,6 +21,7 @@ export {
 export { Input, TextInput } from './Input'
 export { TaskBrowseFilters } from './TaskBrowseFilters/TaskBrowseFilters'
 export { TaskListPagination } from './TaskListPagination/TaskListPagination'
+export { TaskOfferCard } from './TaskOfferCard/TaskOfferCard'
 export * from './Footer'
 export * from './Header'
 export * from './Layout'
@@ -39,3 +42,4 @@ export type {
   UrgencyFilter,
 } from './TaskBrowseFilters/TaskBrowseFilters'
 export type { TaskListPaginationProps } from './TaskListPagination/TaskListPagination'
+export type { TaskOfferCardProps } from './TaskOfferCard/TaskOfferCard'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Stitch-style job hub for `/task/[slug]`: status banner, title and meta row (category, location, posted time), job description card with preferred window and client budget, photo placeholders (API does not expose attachments on this query yet), vertical timeline, and a sticky owner-only offers column with **Accept offer** wired to `acceptOffer`. Non-owners keep the make-offer flow; workers who already quoted see a summary card instead.

## UI primitives

- New `TaskOfferCard` in `src/ui` with Storybook stories.
- `IconCalendar` and `IconDocument` added to `TaskBrowseMetaIcons` for the detail layout.

## Notes

- **Message** links to `/dashboard` until a dedicated messaging route exists.
- **Accept offer** sends `{ offerId }` only; if the API requires an `input` object, follow up with the correct `AcceptOfferInput` shape from codegen.
- Lint (`bun run lint`) still reports existing `any` issues in `.codegen/schema.ts` (unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-15](https://linear.app/handybox/issue/FE-15/refactor-the-task-page-with-the-new-ui-design)

<div><a href="https://cursor.com/agents/bc-6a89cbfb-f738-4a33-8736-da4f17684839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a89cbfb-f738-4a33-8736-da4f17684839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

