### PR TITLE
FE-14: Unified dashboard layout (Master Craftsman shell)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,26 +2,20 @@
 
 import type { TasksQueryData } from '@/graphql/tasks-query.types'
 import { useQuery } from '@apollo/client/react'
-import { Box, HStack, Link, SimpleGrid, Stack } from '@chakra-ui/react'
+import { Box, Grid, GridItem, HStack, Link, Stack } from '@chakra-ui/react'
 import type { MeQuery } from '@codegen/schema'
-import {
-  Badge,
-  Button,
-  Container,
-  Footer,
-  GlassCard,
-  Header,
-  Heading,
-  Text,
-} from '@ui'
+import { Badge, Button, DashboardShell, GlassCard, Heading, Text } from '@ui'
 import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { ME_QUERY } from '@/graphql/auth'
 import { TASKS_QUERY } from '@/graphql/jobs'
 import { clearAuthToken } from '@/utils/auth'
 import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
+
+type TaskItem = TasksQueryData['tasks']['items'][number]
+type TabKey = 'created' | 'quoted'
 
 function formatPounds(pricePence: number) {
   return `£${(pricePence / 100).toFixed(0)}`
@@ -51,6 +45,31 @@ function formatDate(iso: unknown) {
   }).format(d)
 }
 
+function formatRelativePosted(iso: unknown): string {
+  const ms = timeFromUnknown(iso)
+  if (!ms) return 'Recently'
+  const diff = Date.now() - ms
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'Posted just now'
+  if (minutes < 60) return `Posted ${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Posted ${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days === 1) return 'Posted yesterday'
+  if (days < 7) return `Posted ${days} days ago`
+  return `Posted ${formatDate(iso)}`
+}
+
+function isTaskCompleted(status: string) {
+  return /complete|done|closed|paid|archived|finished|resolved/i.test(
+    status.trim(),
+  )
+}
+
+function isOfferAwarded(status: string) {
+  return /accept|award|select|win|approved|chosen/i.test(status.trim())
+}
+
 function getOfferRange(offers: Array<{ pricePence: number }>) {
   if (offers.length === 0) return null
   const prices = offers.map((offer) => offer.pricePence)
@@ -61,8 +80,99 @@ function getOfferRange(offers: Array<{ pricePence: number }>) {
     : `${formatPounds(min)}–${formatPounds(max)}`
 }
 
+function getCategoryVisual(category: string | null | undefined) {
+  const key = (category ?? '').toLowerCase()
+  if (key.includes('plumb') || key.includes('water'))
+    return {
+      glyph: '🏠',
+      bg: 'linear-gradient(135deg, #d9e6ff 0%, #b5ceff 100%)',
+    }
+  if (key.includes('electr'))
+    return {
+      glyph: '🔌',
+      bg: 'linear-gradient(135deg, #dfe8f7 0%, #8fb4ff 100%)',
+    }
+  if (key.includes('paint') || key.includes('decor'))
+    return {
+      glyph: '🎨',
+      bg: 'linear-gradient(135deg, #fff4e4 0%, #ffddb8 100%)',
+    }
+  return {
+    glyph: '🔧',
+    bg: 'linear-gradient(135deg, #eef4ff 0%, #dfe8f7 100%)',
+  }
+}
+
+function matchesSearch(task: TaskItem, q: string) {
+  const s = q.trim().toLowerCase()
+  if (!s) return true
+  return (
+    task.title.toLowerCase().includes(s) ||
+    (task.description ?? '').toLowerCase().includes(s) ||
+    (task.location ?? '').toLowerCase().includes(s)
+  )
+}
+
+function OfferAvatarStack({ count }: { count: number }) {
+  const shown = Math.min(count, 3)
+  const extra = count - shown
+  const letters = ['A', 'B', 'C'] as const
+  return (
+    <HStack gap={0}>
+      {letters.slice(0, shown).map((letter, i) => (
+        <Box
+          key={letter}
+          w={8}
+          h={8}
+          borderRadius="full"
+          bg="primary.200"
+          color="primary.800"
+          fontSize="10px"
+          fontWeight={800}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          borderWidth="2px"
+          borderColor="surfaceContainerLowest"
+          ml={i > 0 ? -2 : 0}
+          zIndex={shown - i}
+        >
+          {letter}
+        </Box>
+      ))}
+      {extra > 0 ? (
+        <Box
+          w={8}
+          h={8}
+          borderRadius="full"
+          bg="surfaceContainerHigh"
+          color="muted"
+          fontSize="xs"
+          fontWeight={700}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          borderWidth="2px"
+          borderColor="surfaceContainerLowest"
+          ml={-2}
+        >
+          +{extra}
+        </Box>
+      ) : null}
+    </HStack>
+  )
+}
+
 export default function DashboardPage() {
   const router = useRouter()
+  const [tab, setTab] = useState<TabKey>('created')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    const v = new URLSearchParams(window.location.search).get('view')
+    if (v === 'quotes') setTab('quoted')
+  }, [])
+
   const {
     data: meData,
     loading: meLoading,
@@ -92,10 +202,10 @@ export default function DashboardPage() {
   const { myPostedTasks, myOffers, offerCountOnMyTasks } = useMemo(() => {
     if (!me) {
       return {
-        myPostedTasks: [] as TasksQueryData['tasks']['items'],
+        myPostedTasks: [] as TaskItem[],
         myOffers: [] as Array<{
-          task: TasksQueryData['tasks']['items'][number]
-          offer: TasksQueryData['tasks']['items'][number]['offers'][number]
+          task: TaskItem
+          offer: TaskItem['offers'][number]
         }>,
         offerCountOnMyTasks: 0,
       }
@@ -130,299 +240,718 @@ export default function DashboardPage() {
     }
   }, [tasks, me])
 
+  const activePosted = useMemo(
+    () =>
+      myPostedTasks.filter(
+        (t) => !isTaskCompleted(t.status) && matchesSearch(t, search),
+      ),
+    [myPostedTasks, search],
+  )
+
+  const quotedFiltered = useMemo(
+    () => myOffers.filter(({ task }) => matchesSearch(task, search)),
+    [myOffers, search],
+  )
+
+  const completedAsPoster = useMemo(
+    () => myPostedTasks.filter((t) => isTaskCompleted(t.status)),
+    [myPostedTasks],
+  )
+
+  const completedAsWorker = useMemo(
+    () => myOffers.filter(({ task }) => isTaskCompleted(task.status)),
+    [myOffers],
+  )
+
+  const completedHistoryItems = useMemo(() => {
+    const poster = completedAsPoster.map((t) => ({
+      kind: 'poster' as const,
+      task: t,
+      at: timeFromUnknown(t.createdAt),
+    }))
+    const worker = completedAsWorker.map(({ task, offer }) => ({
+      kind: 'worker' as const,
+      task,
+      offer,
+      at: timeFromUnknown(offer.createdAt),
+    }))
+    return [...poster, ...worker].sort((a, b) => b.at - a.at).slice(0, 6)
+  }, [completedAsPoster, completedAsWorker])
+
+  const totalSpendPence = useMemo(
+    () =>
+      completedAsPoster.reduce((sum, t) => sum + (t.priceOfferPence ?? 0), 0),
+    [completedAsPoster],
+  )
+
+  const quotesInProgress = useMemo(
+    () =>
+      myOffers.filter(({ task }) => !isTaskCompleted(task.status)).slice(0, 4),
+    [myOffers],
+  )
+
+  const userInitial = me?.email?.trim()?.charAt(0)?.toUpperCase() ?? '?'
+
+  if (!meLoading && !me) {
+    return (
+      <Box bg="bg" color="fg" minH="100vh" py={{ base: 8, md: 12 }} px={4}>
+        <Stack gap={8} maxW="lg" mx="auto">
+          <Box>
+            <Heading size="lg">Dashboard</Heading>
+            <Text color="muted" mt={2}>
+              Manage your posted tasks and quotes in one place.
+            </Text>
+          </Box>
+          {meErrorMessage ? (
+            <Text color="red.400" fontSize="sm">
+              {meErrorMessage}
+            </Text>
+          ) : null}
+          <GlassCard p={6}>
+            <Stack gap={4}>
+              <Heading size="md">Sign in to view your dashboard</Heading>
+              <Text color="muted">
+                You need an account to manage your posted tasks and quotes.
+              </Text>
+              <HStack gap={3} flexWrap="wrap">
+                <Button as={NextLink} href="/login">
+                  Log in
+                </Button>
+                <Button as={NextLink} href="/register" variant="subtle">
+                  Register
+                </Button>
+              </HStack>
+            </Stack>
+          </GlassCard>
+          <HStack gap={4} flexWrap="wrap">
+            <Link
+              as={NextLink}
+              href="/"
+              fontSize="sm"
+              color="muted"
+              _hover={{ color: 'fg' }}
+            >
+              ← Back to home
+            </Link>
+          </HStack>
+        </Stack>
+      </Box>
+    )
+  }
+
   return (
-    <Box bg="bg" color="fg" minH="100vh" py={{ base: 8, md: 12 }}>
-      <Container>
-        <Stack gap={10}>
-          <Header activeItem="my-jobs" />
-          <Stack gap={8}>
-            <Box>
-              <Heading size="lg">Dashboard</Heading>
-              <Text opacity={0.8} mt={2}>
-                Manage your posted tasks and quotes in one place.
-              </Text>
-            </Box>
+    <DashboardShell
+      activeNav="my-jobs"
+      searchValue={search}
+      onSearchChange={setSearch}
+      userLabel={me?.email ?? 'Account'}
+      userInitial={userInitial}
+    >
+      <Stack gap={10}>
+        {meLoading ? <Text color="muted">Loading account…</Text> : null}
+        {meErrorMessage ? (
+          <Text color="red.400" fontSize="sm">
+            {meErrorMessage}
+          </Text>
+        ) : null}
 
-            {meLoading ? <Text>Loading account…</Text> : null}
-            {meErrorMessage ? (
-              <Text color="red.400" fontSize="sm">
-                {meErrorMessage}
-              </Text>
-            ) : null}
-
-            {!meLoading && !me ? (
-              <GlassCard p={6}>
-                <Stack gap={4}>
-                  <Heading size="md">Sign in to view your dashboard</Heading>
-                  <Text color="muted">
-                    You need an account to manage your posted tasks and quotes.
+        {me ? (
+          <>
+            <Stack gap={4}>
+              <HStack
+                justify="space-between"
+                align={{ base: 'flex-start', md: 'center' }}
+                flexDir={{ base: 'column', md: 'row' }}
+                gap={4}
+              >
+                <Stack gap={2} maxW="3xl">
+                  <Heading size="xl">My Jobs</Heading>
+                  <Text color="muted" fontSize="md">
+                    Manage your active projects, track offers, and respond to
+                    quote requests—all in one architectural view.
                   </Text>
-                  <HStack gap={3} flexWrap="wrap">
-                    <Button as={NextLink} href="/login">
-                      Log in
-                    </Button>
-                    <Button as={NextLink} href="/register" variant="subtle">
-                      Register
-                    </Button>
-                  </HStack>
                 </Stack>
-              </GlassCard>
-            ) : null}
+                <Button as={NextLink} href="/tasks/create" flexShrink={0}>
+                  + Post a New Job
+                </Button>
+              </HStack>
 
-            {me ? (
-              <>
-                <GlassCard p={6}>
-                  <Stack gap={5}>
-                    <HStack justify="space-between" flexWrap="wrap" gap={3}>
-                      <Stack gap={1}>
-                        <Text fontWeight="600">Signed in as</Text>
-                        <Text>{me.email}</Text>
-                      </Stack>
-                      <HStack gap={2}>
-                        <Badge bg="surfaceContainerLow" color="fg">
-                          Member since
+              <HStack gap={3} flexWrap="wrap" justify="space-between">
+                <HStack
+                  gap={0}
+                  p={1}
+                  bg="surfaceContainerLow"
+                  borderRadius="full"
+                  borderWidth="1px"
+                  borderColor="border"
+                >
+                  <Button
+                    size="sm"
+                    variant={tab === 'created' ? 'solid' : 'ghost'}
+                    borderRadius="full"
+                    px={5}
+                    onClick={() => setTab('created')}
+                  >
+                    Jobs I&apos;ve Created
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant={tab === 'quoted' ? 'solid' : 'ghost'}
+                    borderRadius="full"
+                    px={5}
+                    onClick={() => setTab('quoted')}
+                  >
+                    Jobs I&apos;ve Quoted
+                  </Button>
+                </HStack>
+                <HStack gap={2} flexWrap="wrap">
+                  <Button
+                    size="sm"
+                    variant="subtle"
+                    onClick={() => {
+                      clearAuthToken()
+                      router.push('/login')
+                    }}
+                  >
+                    Log out
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      void refetchMe()
+                      void refetchTasks()
+                    }}
+                  >
+                    Refresh
+                  </Button>
+                </HStack>
+              </HStack>
+            </Stack>
+
+            <Grid
+              templateColumns={{ base: '1fr', xl: '1fr 340px' }}
+              gap={{ base: 8, xl: 8 }}
+              alignItems="start"
+            >
+              <GridItem>
+                <Stack gap={8}>
+                  {tab === 'created' ? (
+                    <Stack gap={4}>
+                      <HStack gap={3} flexWrap="wrap" align="center">
+                        <Heading size="md">Active Listings</Heading>
+                        <Badge
+                          px={3}
+                          py={1}
+                          borderRadius="full"
+                          bg="primary.100"
+                          color="primary.800"
+                          fontSize="xs"
+                          fontWeight={800}
+                          letterSpacing="0.04em"
+                        >
+                          {activePosted.length} ACTIVE
                         </Badge>
-                        <Text fontSize="sm" color="muted">
-                          {formatDate(me.createdAt)}
-                        </Text>
                       </HStack>
-                    </HStack>
-                    <HStack gap={3} flexWrap="wrap">
-                      <Button
-                        variant="subtle"
-                        bg="surfaceContainerLow"
-                        onClick={() => {
-                          clearAuthToken()
-                          router.push('/login')
-                        }}
-                      >
-                        Log out
-                      </Button>
-                      <Button
-                        onClick={() => {
-                          void refetchMe()
-                          void refetchTasks()
-                        }}
-                      >
-                        Refresh
-                      </Button>
-                      <Button as={NextLink} href="/tasks/create" variant="tool">
-                        Post a new task
-                      </Button>
-                    </HStack>
-                  </Stack>
-                </GlassCard>
 
-                <SimpleGrid columns={{ base: 1, md: 3 }} gap={4}>
-                  <GlassCard p={5}>
-                    <Stack gap={1}>
-                      <Text color="muted" fontSize="sm">
-                        Posted tasks
-                      </Text>
-                      <Heading size="lg">{myPostedTasks.length}</Heading>
-                    </Stack>
-                  </GlassCard>
-                  <GlassCard p={5}>
-                    <Stack gap={1}>
-                      <Text color="muted" fontSize="sm">
-                        Offers on your tasks
-                      </Text>
-                      <Heading size="lg">{offerCountOnMyTasks}</Heading>
-                    </Stack>
-                  </GlassCard>
-                  <GlassCard p={5}>
-                    <Stack gap={1}>
-                      <Text color="muted" fontSize="sm">
-                        Offers you submitted
-                      </Text>
-                      <Heading size="lg">{myOffers.length}</Heading>
-                    </Stack>
-                  </GlassCard>
-                </SimpleGrid>
+                      {tasksLoading ? (
+                        <Text color="muted">Loading tasks…</Text>
+                      ) : null}
+                      {tasksErrorMessage ? (
+                        <Text color="red.400" fontSize="sm">
+                          {tasksErrorMessage}
+                        </Text>
+                      ) : null}
 
-                {tasksLoading ? <Text>Loading tasks and offers…</Text> : null}
-                {tasksErrorMessage ? (
-                  <Text color="red.400" fontSize="sm">
-                    {tasksErrorMessage}
-                  </Text>
-                ) : null}
-
-                {!tasksLoading && !tasksError ? (
-                  <Stack gap={8}>
-                    <GlassCard p={6}>
-                      <Stack gap={5}>
-                        <Heading size="md">Your posted tasks</Heading>
-                        {myPostedTasks.length === 0 ? (
-                          <Text color="muted">
-                            You have not posted any tasks yet.
-                          </Text>
+                      {!tasksLoading && !tasksError ? (
+                        activePosted.length === 0 ? (
+                          <GlassCard p={6}>
+                            <Text color="muted">
+                              No active listings. Post a job to get offers from
+                              verified craftspeople.
+                            </Text>
+                          </GlassCard>
                         ) : (
                           <Stack gap={4}>
-                            {myPostedTasks.map((task) => {
-                              const offerRange = getOfferRange(task.offers)
-                              const latestOffers = [...task.offers]
-                                .sort(
-                                  (a, b) =>
-                                    timeFromUnknown(b.createdAt) -
-                                    timeFromUnknown(a.createdAt),
-                                )
-                                .slice(0, 3)
-
+                            {activePosted.map((task) => {
+                              const visual = getCategoryVisual(task.category)
+                              const n = task.offers.length
                               return (
                                 <GlassCard key={task.id} p={5}>
                                   <Stack gap={4}>
                                     <HStack
-                                      justify="space-between"
                                       align="flex-start"
+                                      gap={4}
                                       flexWrap="wrap"
-                                      gap={3}
                                     >
-                                      <Stack gap={1}>
+                                      <Box
+                                        w={14}
+                                        h={14}
+                                        borderRadius="lg"
+                                        bg={visual.bg}
+                                        display="flex"
+                                        alignItems="center"
+                                        justifyContent="center"
+                                        fontSize="xl"
+                                        flexShrink={0}
+                                      >
+                                        {visual.glyph}
+                                      </Box>
+                                      <Stack gap={1} flex="1" minW="200px">
                                         <Heading size="sm">
                                           {task.title}
                                         </Heading>
-                                        <Text color="muted" fontSize="sm">
-                                          Posted {formatDate(task.createdAt)}
-                                        </Text>
-                                      </Stack>
-                                      <HStack gap={2} flexWrap="wrap">
-                                        {task.location ? (
-                                          <Badge
-                                            bg="surfaceContainerLow"
-                                            color="fg"
-                                          >
-                                            {task.location}
-                                          </Badge>
-                                        ) : null}
-                                        <Badge
-                                          bg="surfaceContainerLow"
-                                          color="fg"
-                                        >
-                                          {task.offers.length} offer
-                                          {task.offers.length === 1 ? '' : 's'}
-                                        </Badge>
-                                        {offerRange ? (
-                                          <Badge px={2}>{offerRange}</Badge>
-                                        ) : null}
-                                      </HStack>
-                                    </HStack>
-
-                                    <Text color="muted">
-                                      {task.description}
-                                    </Text>
-
-                                    {latestOffers.length > 0 ? (
-                                      <Stack gap={2}>
-                                        <Text fontSize="sm" fontWeight={600}>
-                                          Recent offers
-                                        </Text>
-                                        {latestOffers.map((offer) => (
-                                          <HStack
-                                            key={offer.id}
-                                            justify="space-between"
-                                            borderRadius="lg"
-                                            bg="surfaceContainerLow"
-                                            px={3}
-                                            py={2}
-                                          >
-                                            <Stack gap={0}>
-                                              <Text
-                                                fontSize="sm"
-                                                fontWeight={600}
-                                              >
-                                                {formatPounds(offer.pricePence)}
-                                              </Text>
-                                              <Text fontSize="xs" color="muted">
-                                                {offer.message || 'No message'}
-                                              </Text>
-                                            </Stack>
-                                            <Text fontSize="xs" color="muted">
-                                              {formatDate(offer.createdAt)}
+                                        <HStack gap={2} flexWrap="wrap">
+                                          {task.location ? (
+                                            <Text fontSize="sm" color="muted">
+                                              {task.location}
                                             </Text>
-                                          </HStack>
-                                        ))}
+                                          ) : null}
+                                          <Text fontSize="sm" color="muted">
+                                            {formatRelativePosted(
+                                              task.createdAt,
+                                            )}
+                                          </Text>
+                                        </HStack>
                                       </Stack>
-                                    ) : (
-                                      <Text fontSize="sm" color="muted">
-                                        No offers yet.
-                                      </Text>
-                                    )}
-
-                                    <HStack>
-                                      <Button
-                                        as={NextLink}
-                                        href={`/task/${task.id}`}
-                                        size="sm"
-                                        variant="subtle"
-                                        bg="surfaceContainerLow"
+                                      <Stack
+                                        gap={3}
+                                        align={{
+                                          base: 'flex-start',
+                                          sm: 'flex-end',
+                                        }}
                                       >
-                                        View task
-                                      </Button>
+                                        <HStack gap={2} flexWrap="wrap">
+                                          {n > 0 ? (
+                                            <Badge
+                                              px={2}
+                                              py={1}
+                                              borderRadius="md"
+                                              bg="secondaryFixed"
+                                              color="onSecondaryFixed"
+                                              fontSize="10px"
+                                              fontWeight={800}
+                                              letterSpacing="0.06em"
+                                            >
+                                              {n} OFFER{n === 1 ? '' : 'S'}{' '}
+                                              RECEIVED
+                                            </Badge>
+                                          ) : (
+                                            <Badge
+                                              px={2}
+                                              py={1}
+                                              borderRadius="md"
+                                              bg="surfaceContainerHigh"
+                                              color="muted"
+                                              fontSize="10px"
+                                              fontWeight={800}
+                                              letterSpacing="0.06em"
+                                            >
+                                              AWAITING QUOTES
+                                            </Badge>
+                                          )}
+                                          {n > 0 ? (
+                                            <OfferAvatarStack count={n} />
+                                          ) : null}
+                                        </HStack>
+                                        <Button
+                                          as={NextLink}
+                                          href={`/task/${task.id}`}
+                                          size="sm"
+                                          alignSelf={{ sm: 'flex-end' }}
+                                        >
+                                          {n > 0 ? 'View Offers' : 'View Job'}
+                                        </Button>
+                                      </Stack>
                                     </HStack>
+
+                                    {n === 0 ? (
+                                      <Text fontSize="sm" color="muted">
+                                        No offers yet. Share your listing to
+                                        reach more pros, or{' '}
+                                        <Link
+                                          as={NextLink}
+                                          href={`/task/${task.id}`}
+                                          color="primary.600"
+                                          fontWeight={700}
+                                          _hover={{ color: 'primary.700' }}
+                                        >
+                                          boost visibility
+                                        </Link>
+                                        .
+                                      </Text>
+                                    ) : null}
+
+                                    {getOfferRange(task.offers) ? (
+                                      <Text fontSize="xs" color="muted">
+                                        Offer range:{' '}
+                                        {getOfferRange(task.offers)}
+                                      </Text>
+                                    ) : null}
                                   </Stack>
                                 </GlassCard>
                               )
                             })}
                           </Stack>
-                        )}
-                      </Stack>
-                    </GlassCard>
-
-                    <GlassCard p={6}>
-                      <Stack gap={5}>
-                        <Heading size="md">Offers you submitted</Heading>
-                        {myOffers.length === 0 ? (
-                          <Text color="muted">
-                            You have not submitted any offers yet.
-                          </Text>
+                        )
+                      ) : null}
+                    </Stack>
+                  ) : (
+                    <Stack gap={4}>
+                      <HStack gap={3} flexWrap="wrap" align="center">
+                        <Heading size="md">Your quoted jobs</Heading>
+                        <Badge
+                          px={3}
+                          py={1}
+                          borderRadius="full"
+                          bg="surfaceContainerHigh"
+                          color="fg"
+                          fontSize="xs"
+                          fontWeight={800}
+                        >
+                          {quotedFiltered.length} QUOTES
+                        </Badge>
+                      </HStack>
+                      {tasksLoading ? (
+                        <Text color="muted">Loading…</Text>
+                      ) : null}
+                      {!tasksLoading && !tasksError ? (
+                        quotedFiltered.length === 0 ? (
+                          <GlassCard p={6}>
+                            <Text color="muted">
+                              You have not submitted any quotes yet. Browse open
+                              jobs and send your first offer.
+                            </Text>
+                            <Button
+                              as={NextLink}
+                              href="/tasks"
+                              variant="tool"
+                              mt={4}
+                              size="sm"
+                            >
+                              Browse tasks
+                            </Button>
+                          </GlassCard>
                         ) : (
                           <Stack gap={4}>
-                            {myOffers.map(({ task, offer }) => (
-                              <GlassCard key={offer.id} p={5}>
-                                <Stack gap={3}>
+                            {quotedFiltered.map(({ task, offer }) => {
+                              const visual = getCategoryVisual(task.category)
+                              const awarded = isOfferAwarded(offer.status)
+                              return (
+                                <GlassCard key={offer.id} p={5}>
                                   <HStack
-                                    justify="space-between"
                                     align="flex-start"
+                                    gap={4}
                                     flexWrap="wrap"
-                                    gap={3}
                                   >
-                                    <Stack gap={1}>
+                                    <Box
+                                      w={14}
+                                      h={14}
+                                      borderRadius="lg"
+                                      bg={visual.bg}
+                                      display="flex"
+                                      alignItems="center"
+                                      justifyContent="center"
+                                      fontSize="xl"
+                                      flexShrink={0}
+                                    >
+                                      {visual.glyph}
+                                    </Box>
+                                    <Stack gap={2} flex="1" minW="200px">
                                       <Heading size="sm">{task.title}</Heading>
                                       <Text fontSize="sm" color="muted">
-                                        Submitted {formatDate(offer.createdAt)}
+                                        {task.location ?? 'Location TBC'} ·{' '}
+                                        {formatPounds(offer.pricePence)} offer ·{' '}
+                                        {formatRelativePosted(offer.createdAt)}
                                       </Text>
+                                      <Badge
+                                        alignSelf="flex-start"
+                                        px={2}
+                                        py={1}
+                                        borderRadius="md"
+                                        bg={
+                                          awarded
+                                            ? 'secondaryFixed'
+                                            : 'surfaceContainerHigh'
+                                        }
+                                        color={
+                                          awarded ? 'onSecondaryFixed' : 'muted'
+                                        }
+                                        fontSize="10px"
+                                        fontWeight={800}
+                                        letterSpacing="0.06em"
+                                      >
+                                        {awarded ? 'AWARDED' : 'PENDING'}
+                                      </Badge>
                                     </Stack>
-                                    <Badge px={2}>
-                                      {formatPounds(offer.pricePence)}
-                                    </Badge>
-                                  </HStack>
-                                  <Text color="muted">
-                                    {offer.message || 'No message added.'}
-                                  </Text>
-                                  <HStack>
                                     <Button
                                       as={NextLink}
                                       href={`/task/${task.id}`}
                                       size="sm"
                                       variant="subtle"
-                                      bg="surfaceContainerLow"
                                     >
                                       View task
                                     </Button>
                                   </HStack>
-                                </Stack>
-                              </GlassCard>
-                            ))}
+                                </GlassCard>
+                              )
+                            })}
                           </Stack>
-                        )}
+                        )
+                      ) : null}
+                    </Stack>
+                  )}
+                </Stack>
+              </GridItem>
+
+              <GridItem>
+                <Stack gap={4} position={{ xl: 'sticky' }} top={{ xl: 4 }}>
+                  <Box
+                    borderRadius="xl"
+                    bg="linear-gradient(160deg, #03225a 0%, #012b73 55%, #00358f 100%)"
+                    color="white"
+                    p={6}
+                    boxShadow="card"
+                  >
+                    <Stack gap={4}>
+                      <Stack gap={1}>
+                        <Text fontSize="sm" opacity={0.85}>
+                          Total spend (completed)
+                        </Text>
+                        <Heading size="lg" color="white">
+                          {formatPounds(totalSpendPence)}
+                        </Heading>
+                      </Stack>
+                      <Stack gap={1}>
+                        <Text fontSize="sm" opacity={0.85}>
+                          Completed jobs
+                        </Text>
+                        <Heading size="md" color="white">
+                          {completedAsPoster.length}
+                        </Heading>
+                      </Stack>
+                      <Box
+                        borderWidth="1px"
+                        borderStyle="dashed"
+                        borderColor="rgba(255,255,255,0.35)"
+                        borderRadius="lg"
+                        p={4}
+                      >
+                        <Text
+                          fontSize="10px"
+                          fontWeight={800}
+                          letterSpacing="0.1em"
+                          opacity={0.9}
+                          mb={2}
+                        >
+                          ⭐ MASTER STATUS
+                        </Text>
+                        <Text fontSize="sm" lineHeight="tall" opacity={0.92}>
+                          You&apos;re in the top tier of homeowners. Complete
+                          profiles and clear briefs get faster responses from
+                          pros.
+                        </Text>
+                      </Box>
+                    </Stack>
+                  </Box>
+
+                  <GlassCard p={5} bg="primary.50" borderColor="primary.100">
+                    <Stack gap={4}>
+                      <Text
+                        fontSize="xs"
+                        fontWeight={800}
+                        letterSpacing="0.1em"
+                        color="primary.800"
+                      >
+                        QUOTES IN PROGRESS
+                      </Text>
+                      {quotesInProgress.length === 0 ? (
+                        <Text fontSize="sm" color="muted">
+                          No open quotes right now.
+                        </Text>
+                      ) : (
+                        <Stack gap={3}>
+                          {quotesInProgress.map(({ task, offer }) => {
+                            const awarded = isOfferAwarded(offer.status)
+                            return (
+                              <HStack
+                                key={offer.id}
+                                justify="space-between"
+                                align="flex-start"
+                                gap={2}
+                              >
+                                <Stack gap={0}>
+                                  <Text fontWeight={700} fontSize="sm">
+                                    {task.title}
+                                  </Text>
+                                  <Text fontSize="xs" color="muted">
+                                    {formatPounds(offer.pricePence)} offer
+                                  </Text>
+                                </Stack>
+                                <Badge
+                                  px={2}
+                                  py={0.5}
+                                  fontSize="10px"
+                                  fontWeight={800}
+                                  bg={
+                                    awarded
+                                      ? 'secondaryFixed'
+                                      : 'surfaceContainerHigh'
+                                  }
+                                  color={awarded ? 'onSecondaryFixed' : 'muted'}
+                                >
+                                  {awarded ? 'AWARDED' : 'PENDING'}
+                                </Badge>
+                              </HStack>
+                            )
+                          })}
+                        </Stack>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        color="primary.700"
+                        onClick={() => setTab('quoted')}
+                      >
+                        View all quoted jobs
+                      </Button>
+                    </Stack>
+                  </GlassCard>
+
+                  <GlassCard p={5}>
+                    <Stack gap={2} fontSize="sm">
+                      <Text fontWeight={700}>At a glance</Text>
+                      <HStack justify="space-between">
+                        <Text color="muted">Posted tasks</Text>
+                        <Text fontWeight={700}>{myPostedTasks.length}</Text>
+                      </HStack>
+                      <HStack justify="space-between">
+                        <Text color="muted">Offers on your tasks</Text>
+                        <Text fontWeight={700}>{offerCountOnMyTasks}</Text>
+                      </HStack>
+                      <HStack justify="space-between">
+                        <Text color="muted">Quotes you sent</Text>
+                        <Text fontWeight={700}>{myOffers.length}</Text>
+                      </HStack>
+                    </Stack>
+                  </GlassCard>
+                </Stack>
+              </GridItem>
+            </Grid>
+
+            <Stack gap={4}>
+              <Heading size="lg">Completed History</Heading>
+              {completedHistoryItems.length === 0 ? (
+                <GlassCard p={6}>
+                  <Text color="muted">
+                    Completed work will appear here once jobs are marked done.
+                  </Text>
+                </GlassCard>
+              ) : (
+                <Box
+                  overflowX="auto"
+                  pb={2}
+                  css={{
+                    scrollbarWidth: 'thin',
+                  }}
+                >
+                  <HStack align="stretch" gap={4} minW="min-content">
+                    {completedHistoryItems.slice(0, 2).map((item) => {
+                      const task = item.task
+                      const headline =
+                        item.kind === 'poster' ? 'Posted job' : 'Your quote'
+                      return (
+                        <GlassCard
+                          key={`${item.kind}-${task.id}`}
+                          p={5}
+                          minW="280px"
+                          maxW="320px"
+                          bg="surfaceContainerLow"
+                          flexShrink={0}
+                        >
+                          <Stack gap={3}>
+                            <HStack gap={2}>
+                              <Text fontSize="lg">✓</Text>
+                              <Text
+                                fontSize="10px"
+                                fontWeight={800}
+                                letterSpacing="0.08em"
+                                color="muted"
+                              >
+                                {formatDate(task.createdAt).toUpperCase()}
+                              </Text>
+                            </HStack>
+                            <Heading size="sm">{task.title}</Heading>
+                            <Text
+                              fontSize="sm"
+                              color="muted"
+                              css={{
+                                display: '-webkit-box',
+                                WebkitLineClamp: 2,
+                                WebkitBoxOrient: 'vertical',
+                                overflow: 'hidden',
+                              }}
+                            >
+                              {task.description}
+                            </Text>
+                            <HStack justify="space-between" pt={2}>
+                              <Text fontWeight={800}>
+                                {task.priceOfferPence
+                                  ? formatPounds(task.priceOfferPence)
+                                  : '—'}
+                              </Text>
+                              <Link
+                                as={NextLink}
+                                href={`/task/${task.id}`}
+                                fontSize="sm"
+                                fontWeight={700}
+                                color="primary.600"
+                                _hover={{ color: 'primary.700' }}
+                              >
+                                View invoice
+                              </Link>
+                            </HStack>
+                            <Text fontSize="xs" color="muted">
+                              {headline}
+                            </Text>
+                          </Stack>
+                        </GlassCard>
+                      )
+                    })}
+                    <GlassCard
+                      p={5}
+                      minW="240px"
+                      maxW="280px"
+                      flexShrink={0}
+                      bg="surfaceContainerHigh"
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      <Stack gap={3} textAlign="center" align="center">
+                        <Text fontSize="2xl">📄</Text>
+                        <Heading size="sm">Tax &amp; records</Heading>
+                        <Text fontSize="xs" color="muted">
+                          Export a summary of completed work for your records.
+                        </Text>
+                        <Link
+                          href="#"
+                          fontSize="xs"
+                          fontWeight={800}
+                          letterSpacing="0.06em"
+                          color="primary.600"
+                          onClick={(e) => e.preventDefault()}
+                        >
+                          DOWNLOAD SUMMARY
+                        </Link>
                       </Stack>
                     </GlassCard>
-                  </Stack>
-                ) : null}
-              </>
-            ) : null}
+                  </HStack>
+                </Box>
+              )}
+            </Stack>
 
-            <HStack gap={4} flexWrap="wrap">
+            <HStack gap={4} flexWrap="wrap" pt={4}>
               <Link
                 as={NextLink}
                 href="/"
@@ -442,10 +971,9 @@ export default function DashboardPage() {
                 Browse tasks →
               </Link>
             </HStack>
-          </Stack>
-        </Stack>
-      </Container>
-      <Footer />
-    </Box>
+          </>
+        ) : null}
+      </Stack>
+    </DashboardShell>
   )
 }

--- a/src/ui/DashboardShell/DashboardShell.stories.tsx
+++ b/src/ui/DashboardShell/DashboardShell.stories.tsx
@@ -1,0 +1,41 @@
+import { Stack } from '@chakra-ui/react'
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+
+import { Heading, Text } from '../Typography'
+import { DashboardShell } from './DashboardShell'
+
+function DashboardShellStory() {
+  const [search, setSearch] = useState('')
+  return (
+    <DashboardShell
+      activeNav="my-jobs"
+      searchValue={search}
+      onSearchChange={setSearch}
+      userLabel="craftsman@example.com"
+      userInitial="C"
+    >
+      <Stack gap={4}>
+        <Heading size="lg">My Jobs</Heading>
+        <Text color="muted">
+          Shell content area — listings and summaries render here.
+        </Text>
+      </Stack>
+    </DashboardShell>
+  )
+}
+
+const meta = {
+  title: 'layout/DashboardShell',
+  component: DashboardShellStory,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof DashboardShellStory>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/ui/DashboardShell/DashboardShell.tsx
+++ b/src/ui/DashboardShell/DashboardShell.tsx
@@ -1,0 +1,476 @@
+'use client'
+
+import { Box, HStack, Link, Stack } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+import { TextInput } from '../Input'
+import { Heading, Text } from '../Typography'
+
+export type DashboardNavKey =
+  | 'dashboard'
+  | 'my-jobs'
+  | 'quotes'
+  | 'messages'
+  | 'payments'
+  | 'settings'
+  | 'support'
+
+export type DashboardShellProps = {
+  activeNav?: DashboardNavKey
+  searchPlaceholder?: string
+  searchValue: string
+  onSearchChange: (value: string) => void
+  userLabel: string
+  userInitial: string
+  children: React.ReactNode
+}
+
+function NavIcon({
+  children,
+  'aria-hidden': ariaHidden = true,
+}: {
+  children: React.ReactNode
+  'aria-hidden'?: boolean
+}) {
+  return (
+    <Box
+      as="span"
+      w="20px"
+      h="20px"
+      display="inline-flex"
+      alignItems="center"
+      justifyContent="center"
+      flexShrink={0}
+      aria-hidden={ariaHidden}
+    >
+      {children}
+    </Box>
+  )
+}
+
+const navPrimary: Array<{
+  key: DashboardNavKey
+  label: string
+  href: string
+  icon: React.ReactNode
+}> = [
+  {
+    key: 'dashboard',
+    label: 'Dashboard',
+    href: '/',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Dashboard</title>
+        <path
+          d="M4 10.5 12 4l8 6.5V20a1 1 0 0 1-1 1h-5v-6H10v6H5a1 1 0 0 1-1-1v-9.5Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'my-jobs',
+    label: 'My Jobs',
+    href: '/dashboard',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>My Jobs</title>
+        <path
+          d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.36 6.36a2.83 2.83 0 1 1-4-4l6.36-6.36a6 6 0 0 1 7.94-7.94l-3.77 3.77Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'quotes',
+    label: 'Quotes',
+    href: '/dashboard?view=quotes',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Quotes</title>
+        <path
+          d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'messages',
+    label: 'Messages',
+    href: '/dashboard',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Messages</title>
+        <path
+          d="M5 19.5 8.25 17H18a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v12.5Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'payments',
+    label: 'Payments',
+    href: '/dashboard',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Payments</title>
+        <rect
+          x="3"
+          y="5"
+          width="18"
+          height="14"
+          rx="2"
+          stroke="currentColor"
+          strokeWidth="1.75"
+        />
+        <path d="M3 10h18" stroke="currentColor" strokeWidth="1.75" />
+        <path
+          d="M7 15h4"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+]
+
+const navSecondary: Array<{
+  key: DashboardNavKey
+  label: string
+  href: string
+  icon: React.ReactNode
+}> = [
+  {
+    key: 'settings',
+    label: 'Settings',
+    href: '/dashboard',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Settings</title>
+        <path
+          d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+        />
+        <path
+          d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1-1.51V13a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 8 12.6a1.65 1.65 0 0 0-1.82-.33l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 12 8.6V8a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V15c.26.6.74 1.08 1.34 1.34V17a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1.51-1Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'support',
+    label: 'Support',
+    href: '/dashboard',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Support</title>
+        <path
+          d="M9.09 9a3 3 0 1 1 5.83 1c0 2-3 2-3 4"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+        <path
+          d="M12 17h.01"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          stroke="currentColor"
+          strokeWidth="1.75"
+        />
+      </svg>
+    ),
+  },
+]
+
+function SidebarNavLink({
+  href,
+  label,
+  icon,
+  active,
+}: {
+  href: string
+  label: string
+  icon: React.ReactNode
+  active: boolean
+}) {
+  return (
+    <Link
+      as={NextLink}
+      href={href}
+      display="flex"
+      alignItems="center"
+      gap={3}
+      px={3}
+      py={2.5}
+      borderRadius="md"
+      borderLeftWidth="3px"
+      borderLeftColor={active ? 'primary.500' : 'transparent'}
+      bg={active ? 'primary.50' : 'transparent'}
+      color={active ? 'primary.700' : 'muted'}
+      fontWeight={active ? 700 : 600}
+      fontSize="sm"
+      transition="background 0.15s ease, color 0.15s ease"
+      _hover={{
+        textDecoration: 'none',
+        bg: active ? 'primary.50' : 'surfaceContainerLow',
+        color: 'primary.700',
+      }}
+    >
+      <NavIcon>{icon}</NavIcon>
+      {label}
+    </Link>
+  )
+}
+
+export function DashboardShell({
+  activeNav = 'my-jobs',
+  searchPlaceholder = 'Search your jobs…',
+  searchValue,
+  onSearchChange,
+  userLabel,
+  userInitial,
+  children,
+}: DashboardShellProps) {
+  return (
+    <Box minH="100vh" bg="bg" color="fg">
+      <Stack
+        direction={{ base: 'column', md: 'row' }}
+        align="stretch"
+        gap={0}
+        minH="100vh"
+      >
+        <Box
+          as="aside"
+          w={{ base: 'full', md: '260px' }}
+          flexShrink={0}
+          borderRightWidth={{ base: 0, md: '1px' }}
+          borderBottomWidth={{ base: '1px', md: 0 }}
+          borderColor="border"
+          bg="surfaceContainerLowest"
+          px={{ base: 4, md: 5 }}
+          py={{ base: 4, md: 8 }}
+        >
+          <Stack
+            gap={8}
+            maxH={{ md: '100vh' }}
+            position={{ md: 'sticky' }}
+            top={{ md: 0 }}
+          >
+            <HStack gap={3} align="flex-start">
+              <Box
+                w={10}
+                h={10}
+                borderRadius="md"
+                bg="linear-gradient(135deg, #003fb1 0%, #1a56db 100%)"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                color="white"
+                flexShrink={0}
+              >
+                <NavIcon aria-hidden>
+                  <svg viewBox="0 0 24 24" fill="none" width="22" height="22">
+                    <title>HandyBox</title>
+                    <path
+                      d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.36 6.36a2.83 2.83 0 1 1-4-4l6.36-6.36a6 6 0 0 1 7.94-7.94l-3.77 3.77Z"
+                      stroke="currentColor"
+                      strokeWidth="1.75"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </NavIcon>
+              </Box>
+              <Stack gap={0}>
+                <Heading size="sm" lineHeight={1.25}>
+                  HandyBox
+                </Heading>
+                <Text
+                  fontSize="10px"
+                  fontWeight={700}
+                  letterSpacing="0.08em"
+                  color="muted"
+                  textTransform="uppercase"
+                >
+                  Master Craftsman Portal
+                </Text>
+              </Stack>
+            </HStack>
+
+            <Stack gap={1} flex="1">
+              {navPrimary.map((item) => (
+                <SidebarNavLink
+                  key={item.key}
+                  href={item.href}
+                  label={item.label}
+                  icon={item.icon}
+                  active={item.key === activeNav}
+                />
+              ))}
+            </Stack>
+
+            <Stack gap={1} pt={4} borderTopWidth="1px" borderColor="border">
+              {navSecondary.map((item) => (
+                <SidebarNavLink
+                  key={item.key}
+                  href={item.href}
+                  label={item.label}
+                  icon={item.icon}
+                  active={item.key === activeNav}
+                />
+              ))}
+            </Stack>
+          </Stack>
+        </Box>
+
+        <Stack flex="1" minW={0} gap={0}>
+          <HStack
+            as="header"
+            px={{ base: 4, md: 8 }}
+            py={4}
+            borderBottomWidth="1px"
+            borderColor="border"
+            bg="surfaceContainerLowest"
+            gap={4}
+            flexWrap="wrap"
+            align="center"
+          >
+            <Box flex="1" minW="200px" maxW="480px" position="relative">
+              <Box
+                position="absolute"
+                left={3}
+                top="50%"
+                transform="translateY(-50%)"
+                color="muted"
+                pointerEvents="none"
+                zIndex={1}
+              >
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none">
+                  <title>Search</title>
+                  <circle
+                    cx="11"
+                    cy="11"
+                    r="6.5"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                  />
+                  <path
+                    d="m16.5 16.5 4 4"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </Box>
+              <TextInput
+                pl={10}
+                placeholder={searchPlaceholder}
+                value={searchValue}
+                onChange={(e) => onSearchChange(e.target.value)}
+                bg="surfaceContainerLow"
+                borderRadius="full"
+                aria-label="Search jobs"
+              />
+            </Box>
+            <HStack gap={2} ml={{ base: 0, md: 'auto' }}>
+              <Box
+                as="button"
+                w={10}
+                h={10}
+                borderRadius="full"
+                bg="surfaceContainerLow"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                fontSize="lg"
+                aria-label="Notifications"
+              >
+                🔔
+              </Box>
+              <Box
+                as="button"
+                w={10}
+                h={10}
+                borderRadius="full"
+                bg="surfaceContainerLow"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                aria-label="Help"
+              >
+                <svg viewBox="0 0 24 24" width="20" height="20" fill="none">
+                  <title>Help</title>
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="9"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                  />
+                  <path
+                    d="M9.09 9a3 3 0 1 1 5.83 1c0 2-3 2-3 4"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                  />
+                  <path
+                    d="M12 17h.01"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </Box>
+              <Box
+                w={10}
+                h={10}
+                borderRadius="full"
+                bg="primary.500"
+                color="white"
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                fontWeight={800}
+                fontSize="sm"
+                title={userLabel}
+                aria-label={`Account: ${userLabel}`}
+              >
+                {userInitial}
+              </Box>
+            </HStack>
+          </HStack>
+
+          <Box
+            flex="1"
+            px={{ base: 4, md: 8 }}
+            py={{ base: 6, md: 8 }}
+            overflow="auto"
+          >
+            {children}
+          </Box>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -8,14 +8,10 @@ export { AvailableJobsHeader } from './AvailableJobsHeader/AvailableJobsHeader'
 export { Badge } from './Badge'
 export { Button } from './Button'
 export { Container } from './Container'
+export { DashboardShell } from './DashboardShell/DashboardShell'
 export { FormField } from './FormField/FormField'
 export { GlassCard } from './Card/GlassCard'
-export {
-  IconClock,
-  IconMapPin,
-  IconSliders,
-  IconWrench,
-} from './TaskBrowse/TaskBrowseMetaIcons'
+export { IconClock, IconMapPin, IconSliders, IconWrench } from './TaskBrowse/TaskBrowseMetaIcons'
 export { Input, TextInput } from './Input'
 export { TaskBrowseFilters } from './TaskBrowseFilters/TaskBrowseFilters'
 export { TaskListPagination } from './TaskListPagination/TaskListPagination'
@@ -24,18 +20,10 @@ export * from './Header'
 export * from './Layout'
 export * from './PostJobForm'
 export * from './Typography'
-export type {
-  AvailableJobCardProps,
-  JobCardBadgeVariant,
-} from './AvailableJobCard/AvailableJobCard'
-export type {
-  AvailableJobsHeaderProps,
-  SortOption,
-} from './AvailableJobsHeader/AvailableJobsHeader'
+export type { AvailableJobCardProps, JobCardBadgeVariant } from './AvailableJobCard/AvailableJobCard'
+export type { AvailableJobsHeaderProps, SortOption } from './AvailableJobsHeader/AvailableJobsHeader'
+export type { DashboardNavKey, DashboardShellProps } from './DashboardShell/DashboardShell'
 export type { FormFieldProps } from './FormField/FormField'
 export type { GlassCardProps } from './Card/GlassCard'
-export type {
-  TaskBrowseFiltersProps,
-  UrgencyFilter,
-} from './TaskBrowseFilters/TaskBrowseFilters'
+export type { TaskBrowseFiltersProps, UrgencyFilter } from './TaskBrowseFilters/TaskBrowseFilters'
 export type { TaskListPaginationProps } from './TaskListPagination/TaskListPagination'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the unified **Master Craftsman Portal** dashboard layout from FE-14: left-hand navigation, top bar with job search, and a two-column main area aligned with the existing blueprint/amber design tokens.

## What changed

- **`DashboardShell`** (`src/ui/DashboardShell/`): sidebar (HandyBox branding, primary + secondary nav), sticky-style header with search, notification/help/profile affordances, and a scrollable content region. Quotes in the sidebar links to `/dashboard?view=quotes`.
- **`/dashboard` refactor**: pill tabs for **Jobs I've Created** vs **Jobs I've Quoted** (worker view), active listing cards with offer status and CTAs, right column with spend/completed summary, **Quotes in progress**, and at-a-glance stats, plus a **Completed History** horizontal strip and records placeholder.
- **Storybook**: `layout/DashboardShell` story (fullscreen).

## Verification

- `bun run build`
- `npx vitest run` (after `npx playwright install chromium`)

## Notes

- Completed jobs and offer award/pending states use heuristic string matching on API `status` values until the schema exposes explicit enums in the client types.
- “Download summary” in the records card is a placeholder (no backend yet).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-14](https://linear.app/handybox/issue/FE-14/refactor-dashboard-to-the-following-design)

<div><a href="https://cursor.com/agents/bc-6dced32a-9fe1-4ec7-ac64-26eb209b1a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dced32a-9fe1-4ec7-ac64-26eb209b1a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

