### PR TITLE
feat: build routed user and worker dashboard workspaces

### DIFF
--- a/src/app/dashboard/_components/WorkerAccessGate.tsx
+++ b/src/app/dashboard/_components/WorkerAccessGate.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { Stack } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+import { Button, GlassCard, Heading, Text } from '@ui'
+
+export function WorkerAccessGate({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <GlassCard p={{ base: 6, md: 7 }} bg="primary.50" borderColor="primary.100">
+      <Stack gap={4} maxW="2xl">
+        <Heading size="lg">{title}</Heading>
+        <Text color="muted">{description}</Text>
+        <Button as={NextLink} href="/dashboard/worker/register" alignSelf="flex-start">
+          Become a worker
+        </Button>
+      </Stack>
+    </GlassCard>
+  )
+}

--- a/src/app/dashboard/_components/WorkerAccessGate.tsx
+++ b/src/app/dashboard/_components/WorkerAccessGate.tsx
@@ -17,7 +17,11 @@ export function WorkerAccessGate({
       <Stack gap={4} maxW="2xl">
         <Heading size="lg">{title}</Heading>
         <Text color="muted">{description}</Text>
-        <Button as={NextLink} href="/dashboard/worker/register" alignSelf="flex-start">
+        <Button
+          as={NextLink}
+          href="/dashboard/worker/register"
+          alignSelf="flex-start"
+        >
           Become a worker
         </Button>
       </Stack>

--- a/src/app/dashboard/earnings/page.tsx
+++ b/src/app/dashboard/earnings/page.tsx
@@ -66,7 +66,8 @@ export default function DashboardEarningsPage() {
   const projectedPipelinePence =
     filteredOffers
       .filter(({ offer }) => !/reject|declin|cancel/i.test(offer.status))
-      .reduce((sum, { offer }) => sum + offer.pricePence, 0) || averageQuotePence
+      .reduce((sum, { offer }) => sum + offer.pricePence, 0) ||
+    averageQuotePence
 
   const payoutRows =
     awardedQuotes.length > 0
@@ -129,15 +130,25 @@ export default function DashboardEarningsPage() {
                   borderWidth="1px"
                   borderColor="border"
                 >
-                  <HStack justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+                  <HStack
+                    justify="space-between"
+                    align="flex-start"
+                    gap={4}
+                    flexWrap="wrap"
+                  >
                     <Stack gap={1}>
                       <Heading size="sm">{row.title}</Heading>
                       <Text fontSize="sm" color="muted">
                         Expected {formatDate(row.payoutAt.toISOString())}
                       </Text>
                     </Stack>
-                    <Stack gap={2} align={{ base: 'flex-start', md: 'flex-end' }}>
-                      <Text fontWeight={800}>{formatPounds(row.amountPence)}</Text>
+                    <Stack
+                      gap={2}
+                      align={{ base: 'flex-start', md: 'flex-end' }}
+                    >
+                      <Text fontWeight={800}>
+                        {formatPounds(row.amountPence)}
+                      </Text>
                       <Badge
                         bg={
                           row.status === 'Processing'

--- a/src/app/dashboard/earnings/page.tsx
+++ b/src/app/dashboard/earnings/page.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { Grid, HStack, Stack } from '@chakra-ui/react'
+
+import { WorkerAccessGate } from '@/app/dashboard/_components/WorkerAccessGate'
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import { formatDate, formatPounds } from '@/features/dashboard/dashboardHelpers'
+import { Badge, GlassCard, Heading, Text } from '@ui'
+
+function EarningsCard({
+  label,
+  value,
+  helper,
+}: {
+  label: string
+  value: string
+  helper: string
+}) {
+  return (
+    <GlassCard p={5}>
+      <Stack gap={2}>
+        <Text
+          fontSize="10px"
+          fontWeight={800}
+          letterSpacing="0.08em"
+          color="muted"
+          textTransform="uppercase"
+        >
+          {label}
+        </Text>
+        <Heading size="lg">{value}</Heading>
+        <Text fontSize="sm" color="muted">
+          {helper}
+        </Text>
+      </Stack>
+    </GlassCard>
+  )
+}
+
+export default function DashboardEarningsPage() {
+  const {
+    workerEnabled,
+    workerProfile,
+    filteredOffers,
+    awardedQuotes,
+    totalEarningsPence,
+  } = useDashboardData()
+
+  if (!workerEnabled) {
+    return (
+      <WorkerAccessGate
+        title="Earnings tracking unlocks with your worker profile"
+        description="Create a worker profile to access quote totals, payout forecasting, and your worker-side performance summary."
+      />
+    )
+  }
+
+  const averageQuotePence =
+    filteredOffers.length > 0
+      ? Math.round(
+          filteredOffers.reduce((sum, { offer }) => sum + offer.pricePence, 0) /
+            filteredOffers.length,
+        )
+      : workerProfile.hourlyRatePence * 4
+
+  const projectedPipelinePence =
+    filteredOffers
+      .filter(({ offer }) => !/reject|declin|cancel/i.test(offer.status))
+      .reduce((sum, { offer }) => sum + offer.pricePence, 0) || averageQuotePence
+
+  const payoutRows =
+    awardedQuotes.length > 0
+      ? awardedQuotes.slice(0, 4).map(({ task, offer }, index) => ({
+          id: offer.id,
+          title: task.title,
+          amountPence: offer.pricePence,
+          status: index === 0 ? 'Processing' : 'Scheduled',
+          payoutAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * (index + 2)),
+        }))
+      : [
+          {
+            id: 'forecast-1',
+            title: 'First completed worker payout',
+            amountPence: averageQuotePence,
+            status: 'Forecast',
+            payoutAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+          },
+        ]
+
+  return (
+    <Stack gap={8}>
+      <Stack gap={2}>
+        <Heading size="xl">Earnings</Heading>
+        <Text color="muted" maxW="3xl">
+          This worker workspace mixes live awarded quote data with demo payout
+          forecasting so the frontend can showcase earnings flow even while the
+          backend payout APIs are still limited.
+        </Text>
+      </Stack>
+
+      <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={4}>
+        <EarningsCard
+          label="Tracked earnings"
+          value={formatPounds(totalEarningsPence)}
+          helper="Awarded quote value pulled from the current tasks schema."
+        />
+        <EarningsCard
+          label="Average quote"
+          value={formatPounds(averageQuotePence)}
+          helper="Based on live sent quotes or your configured worker rate."
+        />
+        <EarningsCard
+          label="Pipeline forecast"
+          value={formatPounds(projectedPipelinePence)}
+          helper="Open worker opportunity value still active in your queue."
+        />
+      </Grid>
+
+      <Grid templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }} gap={6}>
+        <GlassCard p={6}>
+          <Stack gap={4}>
+            <Heading size="md">Payout queue</Heading>
+            <Stack gap={3}>
+              {payoutRows.map((row) => (
+                <GlassCard
+                  key={row.id}
+                  p={4}
+                  bg="surfaceContainerLow"
+                  borderWidth="1px"
+                  borderColor="border"
+                >
+                  <HStack justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+                    <Stack gap={1}>
+                      <Heading size="sm">{row.title}</Heading>
+                      <Text fontSize="sm" color="muted">
+                        Expected {formatDate(row.payoutAt.toISOString())}
+                      </Text>
+                    </Stack>
+                    <Stack gap={2} align={{ base: 'flex-start', md: 'flex-end' }}>
+                      <Text fontWeight={800}>{formatPounds(row.amountPence)}</Text>
+                      <Badge
+                        bg={
+                          row.status === 'Processing'
+                            ? 'secondaryFixed'
+                            : row.status === 'Scheduled'
+                              ? 'primary.50'
+                              : 'surfaceContainerHigh'
+                        }
+                        color={
+                          row.status === 'Processing'
+                            ? 'onSecondaryFixed'
+                            : row.status === 'Scheduled'
+                              ? 'primary.700'
+                              : 'fg'
+                        }
+                      >
+                        {row.status}
+                      </Badge>
+                    </Stack>
+                  </HStack>
+                </GlassCard>
+              ))}
+            </Stack>
+          </Stack>
+        </GlassCard>
+
+        <GlassCard
+          p={6}
+          bg="linear-gradient(160deg, #03225a 0%, #012b73 55%, #00358f 100%)"
+          color="white"
+        >
+          <Stack gap={4}>
+            <Heading size="md" color="white">
+              Worker profile summary
+            </Heading>
+            <HStack justify="space-between">
+              <Text color="whiteAlpha.800">Business</Text>
+              <Text fontWeight={700}>
+                {workerProfile.businessName || 'Independent pro'}
+              </Text>
+            </HStack>
+            <HStack justify="space-between">
+              <Text color="whiteAlpha.800">Service area</Text>
+              <Text fontWeight={700}>{workerProfile.serviceArea}</Text>
+            </HStack>
+            <HStack justify="space-between">
+              <Text color="whiteAlpha.800">Rate target</Text>
+              <Text fontWeight={700}>
+                {formatPounds(workerProfile.hourlyRatePence)}/hr
+              </Text>
+            </HStack>
+            <HStack justify="space-between">
+              <Text color="whiteAlpha.800">Skills</Text>
+              <Text fontWeight={700}>
+                {workerProfile.skills.join(', ') || 'No skills selected'}
+              </Text>
+            </HStack>
+          </Stack>
+        </GlassCard>
+      </Grid>
+    </Stack>
+  )
+}

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { Grid, HStack, Stack } from '@chakra-ui/react'
+
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import { formatDate, formatPounds } from '@/features/dashboard/dashboardHelpers'
+import { Badge, GlassCard, Heading, Text } from '@ui'
+
+export default function DashboardHistoryPage() {
+  const { search, serviceHistory } = useDashboardData()
+
+  const filteredHistory = serviceHistory.filter((entry) => {
+    const q = search.trim().toLowerCase()
+    if (!q) return true
+
+    return (
+      entry.title.toLowerCase().includes(q) ||
+      entry.location.toLowerCase().includes(q) ||
+      entry.summary.toLowerCase().includes(q) ||
+      entry.role.toLowerCase().includes(q)
+    )
+  })
+
+  const totalHistoryValue = filteredHistory.reduce(
+    (sum, entry) => sum + entry.valuePence,
+    0,
+  )
+
+  return (
+    <Stack gap={8}>
+      <Stack gap={2}>
+        <Heading size="xl">Service History</Heading>
+        <Text color="muted" maxW="3xl">
+          Review completed jobs, archived work, and quick financial records for
+          both customer and worker activity.
+        </Text>
+      </Stack>
+
+      <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={4}>
+        <GlassCard p={5}>
+          <Stack gap={2}>
+            <Text fontSize="10px" fontWeight={800} letterSpacing="0.08em" color="muted">
+              HISTORY ITEMS
+            </Text>
+            <Heading size="lg">{filteredHistory.length}</Heading>
+            <Text fontSize="sm" color="muted">
+              Records matching the current dashboard search.
+            </Text>
+          </Stack>
+        </GlassCard>
+        <GlassCard p={5}>
+          <Stack gap={2}>
+            <Text fontSize="10px" fontWeight={800} letterSpacing="0.08em" color="muted">
+              TOTAL VALUE
+            </Text>
+            <Heading size="lg">{formatPounds(totalHistoryValue)}</Heading>
+            <Text fontSize="sm" color="muted">
+              Combined customer and worker record value shown on this page.
+            </Text>
+          </Stack>
+        </GlassCard>
+        <GlassCard p={5}>
+          <Stack gap={2}>
+            <Text fontSize="10px" fontWeight={800} letterSpacing="0.08em" color="muted">
+              EXPORT STATUS
+            </Text>
+            <Heading size="lg">Ready</Heading>
+            <Text fontSize="sm" color="muted">
+              Demo-ready record summaries can be exported from future API work.
+            </Text>
+          </Stack>
+        </GlassCard>
+      </Grid>
+
+      {filteredHistory.length === 0 ? (
+        <GlassCard p={6}>
+          <Text color="muted">
+            No history items match your current search. Try a task title,
+            location, or role such as customer or worker.
+          </Text>
+        </GlassCard>
+      ) : (
+        <Stack gap={4}>
+          {filteredHistory.map((entry) => (
+            <GlassCard key={entry.id} p={5}>
+              <HStack justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+                <Stack gap={2} maxW="3xl">
+                  <HStack gap={2} flexWrap="wrap">
+                    <Heading size="sm">{entry.title}</Heading>
+                    <Badge
+                      bg={entry.role === 'worker' ? 'primary.50' : 'surfaceContainerHigh'}
+                      color={entry.role === 'worker' ? 'primary.700' : 'fg'}
+                    >
+                      {entry.role === 'worker' ? 'Worker record' : 'Customer record'}
+                    </Badge>
+                  </HStack>
+                  <Text fontSize="sm" color="muted">
+                    {entry.location} · {formatDate(entry.completedAt)}
+                  </Text>
+                  <Text fontSize="sm">{entry.summary}</Text>
+                </Stack>
+                <Text fontWeight={800}>{formatPounds(entry.valuePence)}</Text>
+              </HStack>
+            </GlassCard>
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  )
+}

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -39,7 +39,12 @@ export default function DashboardHistoryPage() {
       <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={4}>
         <GlassCard p={5}>
           <Stack gap={2}>
-            <Text fontSize="10px" fontWeight={800} letterSpacing="0.08em" color="muted">
+            <Text
+              fontSize="10px"
+              fontWeight={800}
+              letterSpacing="0.08em"
+              color="muted"
+            >
               HISTORY ITEMS
             </Text>
             <Heading size="lg">{filteredHistory.length}</Heading>
@@ -50,7 +55,12 @@ export default function DashboardHistoryPage() {
         </GlassCard>
         <GlassCard p={5}>
           <Stack gap={2}>
-            <Text fontSize="10px" fontWeight={800} letterSpacing="0.08em" color="muted">
+            <Text
+              fontSize="10px"
+              fontWeight={800}
+              letterSpacing="0.08em"
+              color="muted"
+            >
               TOTAL VALUE
             </Text>
             <Heading size="lg">{formatPounds(totalHistoryValue)}</Heading>
@@ -61,7 +71,12 @@ export default function DashboardHistoryPage() {
         </GlassCard>
         <GlassCard p={5}>
           <Stack gap={2}>
-            <Text fontSize="10px" fontWeight={800} letterSpacing="0.08em" color="muted">
+            <Text
+              fontSize="10px"
+              fontWeight={800}
+              letterSpacing="0.08em"
+              color="muted"
+            >
               EXPORT STATUS
             </Text>
             <Heading size="lg">Ready</Heading>
@@ -83,15 +98,26 @@ export default function DashboardHistoryPage() {
         <Stack gap={4}>
           {filteredHistory.map((entry) => (
             <GlassCard key={entry.id} p={5}>
-              <HStack justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+              <HStack
+                justify="space-between"
+                align="flex-start"
+                gap={4}
+                flexWrap="wrap"
+              >
                 <Stack gap={2} maxW="3xl">
                   <HStack gap={2} flexWrap="wrap">
                     <Heading size="sm">{entry.title}</Heading>
                     <Badge
-                      bg={entry.role === 'worker' ? 'primary.50' : 'surfaceContainerHigh'}
+                      bg={
+                        entry.role === 'worker'
+                          ? 'primary.50'
+                          : 'surfaceContainerHigh'
+                      }
                       color={entry.role === 'worker' ? 'primary.700' : 'fg'}
                     >
-                      {entry.role === 'worker' ? 'Worker record' : 'Customer record'}
+                      {entry.role === 'worker'
+                        ? 'Worker record'
+                        : 'Customer record'}
                     </Badge>
                   </HStack>
                   <Text fontSize="sm" color="muted">

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -1,0 +1,278 @@
+'use client'
+
+import { Box, Grid, HStack, Link, Stack } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import {
+  formatRelativePosted,
+  getCategoryVisual,
+  getOfferRange,
+} from '@/features/dashboard/dashboardHelpers'
+import { Badge, Button, GlassCard, Heading, Text } from '@ui'
+
+function OfferAvatarStack({ count }: { count: number }) {
+  const shown = Math.min(count, 3)
+  const extra = count - shown
+  const letters = ['A', 'B', 'C'] as const
+
+  return (
+    <HStack gap={0}>
+      {letters.slice(0, shown).map((letter, index) => (
+        <Box
+          key={letter}
+          w={8}
+          h={8}
+          borderRadius="full"
+          bg="primary.200"
+          color="primary.800"
+          fontSize="10px"
+          fontWeight={800}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          borderWidth="2px"
+          borderColor="surfaceContainerLowest"
+          ml={index > 0 ? -2 : 0}
+          zIndex={shown - index}
+        >
+          {letter}
+        </Box>
+      ))}
+      {extra > 0 ? (
+        <Box
+          w={8}
+          h={8}
+          borderRadius="full"
+          bg="surfaceContainerHigh"
+          color="muted"
+          fontSize="xs"
+          fontWeight={700}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          borderWidth="2px"
+          borderColor="surfaceContainerLowest"
+          ml={-2}
+        >
+          +{extra}
+        </Box>
+      ) : null}
+    </HStack>
+  )
+}
+
+export default function DashboardJobsPage() {
+  const {
+    tasksLoading,
+    tasksErrorMessage,
+    filteredPostedTasks,
+    customerBookings,
+    offerCountOnMyTasks,
+  } = useDashboardData()
+
+  return (
+    <Stack gap={8}>
+      <Stack gap={2}>
+        <HStack justify="space-between" gap={4} flexWrap="wrap">
+          <Stack gap={1} maxW="3xl">
+            <Heading size="xl">My Jobs</Heading>
+            <Text color="muted">
+              Review the jobs you have posted, check quote activity, and jump
+              into booking details from one customer workspace.
+            </Text>
+          </Stack>
+          <Button as={NextLink} href="/tasks/create">
+            + Post a New Job
+          </Button>
+        </HStack>
+      </Stack>
+
+      <Grid templateColumns={{ base: '1fr', xl: '1fr 320px' }} gap={6} alignItems="start">
+        <Stack gap={4}>
+          <HStack gap={3} flexWrap="wrap" align="center">
+            <Heading size="md">Active listings</Heading>
+            <Badge bg="primary.50" color="primary.700">
+              {filteredPostedTasks.length} active
+            </Badge>
+          </HStack>
+
+          {tasksLoading ? <Text color="muted">Loading tasks…</Text> : null}
+          {tasksErrorMessage ? (
+            <Text color="red.400" fontSize="sm">
+              {tasksErrorMessage}
+            </Text>
+          ) : null}
+
+          {!tasksLoading && !tasksErrorMessage ? (
+            filteredPostedTasks.length === 0 ? (
+              <GlassCard p={6}>
+                <Stack gap={3}>
+                  <Heading size="sm">No active listings yet</Heading>
+                  <Text color="muted">
+                    Post your first job to start receiving quotes and booking
+                    responses from local pros.
+                  </Text>
+                  <Button as={NextLink} href="/tasks/create" alignSelf="flex-start">
+                    Post a new job
+                  </Button>
+                </Stack>
+              </GlassCard>
+            ) : (
+              <Stack gap={4}>
+                {filteredPostedTasks.map((task) => {
+                  const visual = getCategoryVisual(task.category)
+                  const offerCount = task.offers.length
+
+                  return (
+                    <GlassCard key={task.id} p={5}>
+                      <Stack gap={4}>
+                        <HStack align="flex-start" gap={4} flexWrap="wrap">
+                          <Box
+                            w={14}
+                            h={14}
+                            borderRadius="lg"
+                            bg={visual.bg}
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            fontSize="xl"
+                            flexShrink={0}
+                          >
+                            {visual.glyph}
+                          </Box>
+                          <Stack gap={1} flex="1" minW="220px">
+                            <Heading size="sm">{task.title}</Heading>
+                            <HStack gap={2} flexWrap="wrap">
+                              <Text fontSize="sm" color="muted">
+                                {task.location ?? 'Location TBC'}
+                              </Text>
+                              <Text fontSize="sm" color="muted">
+                                {formatRelativePosted(task.createdAt)}
+                              </Text>
+                            </HStack>
+                            <Text fontSize="sm" color="muted">
+                              {task.description}
+                            </Text>
+                          </Stack>
+                          <Stack
+                            gap={3}
+                            align={{ base: 'flex-start', md: 'flex-end' }}
+                          >
+                            <HStack gap={2} flexWrap="wrap">
+                              <Badge
+                                bg={
+                                  offerCount > 0
+                                    ? 'secondaryFixed'
+                                    : 'surfaceContainerHigh'
+                                }
+                                color={offerCount > 0 ? 'onSecondaryFixed' : 'fg'}
+                              >
+                                {offerCount > 0
+                                  ? `${offerCount} quote${offerCount === 1 ? '' : 's'}`
+                                  : 'Awaiting quotes'}
+                              </Badge>
+                              {offerCount > 0 ? (
+                                <OfferAvatarStack count={offerCount} />
+                              ) : null}
+                            </HStack>
+                            <Button as={NextLink} href={`/task/${task.id}`} size="sm">
+                              {offerCount > 0 ? 'View quotes' : 'View job'}
+                            </Button>
+                          </Stack>
+                        </HStack>
+
+                        {getOfferRange(task.offers) ? (
+                          <Text fontSize="xs" color="muted">
+                            Current quote range: {getOfferRange(task.offers)}
+                          </Text>
+                        ) : (
+                          <Text fontSize="xs" color="muted">
+                            No quotes yet. Share your brief or refine the scope
+                            for faster responses.
+                          </Text>
+                        )}
+                      </Stack>
+                    </GlassCard>
+                  )
+                })}
+              </Stack>
+            )
+          ) : null}
+        </Stack>
+
+        <Stack gap={4} position={{ xl: 'sticky' }} top={{ xl: 4 }}>
+          <GlassCard
+            p={5}
+            bg="linear-gradient(160deg, #03225a 0%, #012b73 55%, #00358f 100%)"
+            color="white"
+          >
+            <Stack gap={4}>
+              <Stack gap={1}>
+                <Text fontSize="sm" opacity={0.85}>
+                  Booking-ready jobs
+                </Text>
+                <Heading size="lg" color="white">
+                  {customerBookings.length}
+                </Heading>
+              </Stack>
+              <Stack gap={1}>
+                <Text fontSize="sm" opacity={0.85}>
+                  Quotes received
+                </Text>
+                <Heading size="md" color="white">
+                  {offerCountOnMyTasks}
+                </Heading>
+              </Stack>
+              <Text fontSize="sm" opacity={0.9}>
+                Every job with incoming quotes stays linked to its existing task
+                detail page so you can review, compare, and book from live data.
+              </Text>
+            </Stack>
+          </GlassCard>
+
+          <GlassCard p={5} bg="surfaceContainerLow">
+            <Stack gap={4}>
+              <Heading size="sm">Booking board</Heading>
+              {customerBookings.length === 0 ? (
+                <Text fontSize="sm" color="muted">
+                  When quotes arrive, the most active jobs will appear here for
+                  quick follow-up.
+                </Text>
+              ) : (
+                <Stack gap={3}>
+                  {customerBookings.slice(0, 4).map((task) => (
+                    <GlassCard
+                      key={task.id}
+                      p={4}
+                      bg="surfaceContainerLowest"
+                      borderWidth="1px"
+                      borderColor="border"
+                    >
+                      <Stack gap={1}>
+                        <Heading size="sm">{task.title}</Heading>
+                        <Text fontSize="sm" color="muted">
+                          {task.offers.length} quotes · {task.location ?? 'Location TBC'}
+                        </Text>
+                        <Link
+                          as={NextLink}
+                          href={`/task/${task.id}`}
+                          fontSize="sm"
+                          fontWeight={700}
+                          color="primary.600"
+                          _hover={{ color: 'primary.700' }}
+                        >
+                          Open booking details
+                        </Link>
+                      </Stack>
+                    </GlassCard>
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+          </GlassCard>
+        </Stack>
+      </Grid>
+    </Stack>
+  )
+}

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -65,11 +65,14 @@ function OfferAvatarStack({ count }: { count: number }) {
 export default function DashboardJobsPage() {
   const {
     tasksLoading,
+    tasksBootstrapping,
     tasksErrorMessage,
     filteredPostedTasks,
     customerBookings,
     offerCountOnMyTasks,
   } = useDashboardData()
+
+  const isLoadingTaskBoard = tasksLoading || tasksBootstrapping
 
   return (
     <Stack gap={8}>
@@ -88,7 +91,11 @@ export default function DashboardJobsPage() {
         </HStack>
       </Stack>
 
-      <Grid templateColumns={{ base: '1fr', xl: '1fr 320px' }} gap={6} alignItems="start">
+      <Grid
+        templateColumns={{ base: '1fr', xl: '1fr 320px' }}
+        gap={6}
+        alignItems="start"
+      >
         <Stack gap={4}>
           <HStack gap={3} flexWrap="wrap" align="center">
             <Heading size="md">Active listings</Heading>
@@ -97,14 +104,16 @@ export default function DashboardJobsPage() {
             </Badge>
           </HStack>
 
-          {tasksLoading ? <Text color="muted">Loading tasks…</Text> : null}
+          {isLoadingTaskBoard ? (
+            <Text color="muted">Loading tasks…</Text>
+          ) : null}
           {tasksErrorMessage ? (
             <Text color="red.400" fontSize="sm">
               {tasksErrorMessage}
             </Text>
           ) : null}
 
-          {!tasksLoading && !tasksErrorMessage ? (
+          {!isLoadingTaskBoard && !tasksErrorMessage ? (
             filteredPostedTasks.length === 0 ? (
               <GlassCard p={6}>
                 <Stack gap={3}>
@@ -113,7 +122,11 @@ export default function DashboardJobsPage() {
                     Post your first job to start receiving quotes and booking
                     responses from local pros.
                   </Text>
-                  <Button as={NextLink} href="/tasks/create" alignSelf="flex-start">
+                  <Button
+                    as={NextLink}
+                    href="/tasks/create"
+                    alignSelf="flex-start"
+                  >
                     Post a new job
                   </Button>
                 </Stack>
@@ -166,7 +179,9 @@ export default function DashboardJobsPage() {
                                     ? 'secondaryFixed'
                                     : 'surfaceContainerHigh'
                                 }
-                                color={offerCount > 0 ? 'onSecondaryFixed' : 'fg'}
+                                color={
+                                  offerCount > 0 ? 'onSecondaryFixed' : 'fg'
+                                }
                               >
                                 {offerCount > 0
                                   ? `${offerCount} quote${offerCount === 1 ? '' : 's'}`
@@ -176,7 +191,11 @@ export default function DashboardJobsPage() {
                                 <OfferAvatarStack count={offerCount} />
                               ) : null}
                             </HStack>
-                            <Button as={NextLink} href={`/task/${task.id}`} size="sm">
+                            <Button
+                              as={NextLink}
+                              href={`/task/${task.id}`}
+                              size="sm"
+                            >
                               {offerCount > 0 ? 'View quotes' : 'View job'}
                             </Button>
                           </Stack>
@@ -252,7 +271,8 @@ export default function DashboardJobsPage() {
                       <Stack gap={1}>
                         <Heading size="sm">{task.title}</Heading>
                         <Text fontSize="sm" color="muted">
-                          {task.offers.length} quotes · {task.location ?? 'Location TBC'}
+                          {task.offers.length} quotes ·{' '}
+                          {task.location ?? 'Location TBC'}
                         </Text>
                         <Link
                           as={NextLink}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -11,8 +11,8 @@ import {
 import { clearAuthToken } from '@/utils/auth'
 import {
   Button,
-  DashboardShell,
   type DashboardNavKey,
+  DashboardShell,
   GlassCard,
   Heading,
   Text,
@@ -25,7 +25,8 @@ function resolveActiveNav(pathname: string): DashboardNavKey {
   if (pathname.startsWith('/dashboard/history')) return 'history'
   if (pathname.startsWith('/dashboard/messages')) return 'messages'
   if (pathname.startsWith('/dashboard/profile')) return 'profile'
-  if (pathname.startsWith('/dashboard/worker/register')) return 'worker-register'
+  if (pathname.startsWith('/dashboard/worker/register'))
+    return 'worker-register'
   return 'overview'
 }
 
@@ -100,7 +101,9 @@ function DashboardChrome({ children }: { children: React.ReactNode }) {
       onSearchChange={setSearch}
       userLabel={displayName}
       userInitial={userInitial}
-      userStatus={workerEnabled ? 'Verified worker workspace' : 'Customer dashboard'}
+      userStatus={
+        workerEnabled ? 'Verified worker workspace' : 'Customer dashboard'
+      }
       userMeta={me?.email ?? ''}
       workerEnabled={workerEnabled}
       headerAction={

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { Box, HStack, Link, Stack } from '@chakra-ui/react'
+import NextLink from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+
+import {
+  DashboardDataProvider,
+  useDashboardData,
+} from '@/features/dashboard/DashboardDataContext'
+import { clearAuthToken } from '@/utils/auth'
+import {
+  Button,
+  DashboardShell,
+  type DashboardNavKey,
+  GlassCard,
+  Heading,
+  Text,
+} from '@ui'
+
+function resolveActiveNav(pathname: string): DashboardNavKey {
+  if (pathname.startsWith('/dashboard/jobs')) return 'jobs'
+  if (pathname.startsWith('/dashboard/quotes')) return 'quotes'
+  if (pathname.startsWith('/dashboard/earnings')) return 'earnings'
+  if (pathname.startsWith('/dashboard/history')) return 'history'
+  if (pathname.startsWith('/dashboard/messages')) return 'messages'
+  if (pathname.startsWith('/dashboard/profile')) return 'profile'
+  if (pathname.startsWith('/dashboard/worker/register')) return 'worker-register'
+  return 'overview'
+}
+
+function DashboardChrome({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const {
+    me,
+    meLoading,
+    meErrorMessage,
+    refetchDashboardData,
+    search,
+    setSearch,
+    displayName,
+    userInitial,
+    workerEnabled,
+  } = useDashboardData()
+
+  if (!meLoading && !me) {
+    return (
+      <Box bg="bg" color="fg" minH="100vh" py={{ base: 8, md: 12 }} px={4}>
+        <Stack gap={8} maxW="lg" mx="auto">
+          <Box>
+            <Heading size="lg">Dashboard</Heading>
+            <Text color="muted" mt={2}>
+              Sign in to manage posted jobs, track quotes, and unlock worker
+              tools.
+            </Text>
+          </Box>
+          {meErrorMessage ? (
+            <Text color="red.400" fontSize="sm">
+              {meErrorMessage}
+            </Text>
+          ) : null}
+          <GlassCard p={6}>
+            <Stack gap={4}>
+              <Heading size="md">Sign in to view your dashboard</Heading>
+              <Text color="muted">
+                You need an account to access jobs, bookings, history, profile,
+                and worker registration.
+              </Text>
+              <HStack gap={3} flexWrap="wrap">
+                <Button as={NextLink} href="/login">
+                  Log in
+                </Button>
+                <Button as={NextLink} href="/register" variant="subtle">
+                  Register
+                </Button>
+              </HStack>
+            </Stack>
+          </GlassCard>
+          <Link
+            as={NextLink}
+            href="/"
+            fontSize="sm"
+            color="muted"
+            _hover={{ color: 'fg' }}
+          >
+            ← Back to home
+          </Link>
+        </Stack>
+      </Box>
+    )
+  }
+
+  const activeNav = resolveActiveNav(pathname)
+
+  return (
+    <DashboardShell
+      activeNav={activeNav}
+      searchValue={search}
+      onSearchChange={setSearch}
+      userLabel={displayName}
+      userInitial={userInitial}
+      userStatus={workerEnabled ? 'Verified worker workspace' : 'Customer dashboard'}
+      userMeta={me?.email ?? ''}
+      workerEnabled={workerEnabled}
+      headerAction={
+        <HStack gap={2} flexWrap="wrap">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => refetchDashboardData()}
+          >
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            variant="subtle"
+            onClick={() => {
+              clearAuthToken()
+              router.push('/login')
+            }}
+          >
+            Log out
+          </Button>
+        </HStack>
+      }
+    >
+      {children}
+    </DashboardShell>
+  )
+}
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <DashboardDataProvider>
+      <DashboardChrome>{children}</DashboardChrome>
+    </DashboardDataProvider>
+  )
+}

--- a/src/app/dashboard/messages/page.tsx
+++ b/src/app/dashboard/messages/page.tsx
@@ -20,7 +20,9 @@ export default function DashboardMessagesPage() {
     )
   })
 
-  const unreadCount = filteredMessages.filter((message) => message.unread).length
+  const unreadCount = filteredMessages.filter(
+    (message) => message.unread,
+  ).length
 
   return (
     <Stack gap={8}>
@@ -62,7 +64,12 @@ export default function DashboardMessagesPage() {
           {filteredMessages.map((message) => (
             <GlassCard key={message.id} p={5}>
               <Stack gap={3}>
-                <HStack justify="space-between" align="flex-start" gap={3} flexWrap="wrap">
+                <HStack
+                  justify="space-between"
+                  align="flex-start"
+                  gap={3}
+                  flexWrap="wrap"
+                >
                   <Stack gap={1}>
                     <HStack gap={2} flexWrap="wrap">
                       <Heading size="sm">{message.counterpart}</Heading>

--- a/src/app/dashboard/messages/page.tsx
+++ b/src/app/dashboard/messages/page.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { HStack, Stack } from '@chakra-ui/react'
+
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import { formatDate } from '@/features/dashboard/dashboardHelpers'
+import { Badge, Button, GlassCard, Heading, Text } from '@ui'
+
+export default function DashboardMessagesPage() {
+  const { search, messages, markAllMessagesRead } = useDashboardData()
+
+  const filteredMessages = messages.filter((message) => {
+    const q = search.trim().toLowerCase()
+    if (!q) return true
+
+    return (
+      message.counterpart.toLowerCase().includes(q) ||
+      message.taskTitle.toLowerCase().includes(q) ||
+      message.preview.toLowerCase().includes(q)
+    )
+  })
+
+  const unreadCount = filteredMessages.filter((message) => message.unread).length
+
+  return (
+    <Stack gap={8}>
+      <HStack justify="space-between" gap={4} flexWrap="wrap">
+        <Stack gap={1} maxW="3xl">
+          <Heading size="xl">Messages</Heading>
+          <Text color="muted">
+            Keep up with job updates, worker onboarding notes, and scheduling
+            conversations from one place.
+          </Text>
+        </Stack>
+        <Button
+          variant="subtle"
+          onClick={() => markAllMessagesRead()}
+          disabled={unreadCount === 0}
+        >
+          Mark all as read
+        </Button>
+      </HStack>
+
+      <HStack gap={3} flexWrap="wrap">
+        <Badge bg="primary.50" color="primary.700">
+          {filteredMessages.length} conversations
+        </Badge>
+        <Badge bg="surfaceContainerHigh" color="fg">
+          {unreadCount} unread
+        </Badge>
+      </HStack>
+
+      {filteredMessages.length === 0 ? (
+        <GlassCard p={6}>
+          <Text color="muted">
+            No messages match your current search. Clear the search box to view
+            all recent dashboard communication.
+          </Text>
+        </GlassCard>
+      ) : (
+        <Stack gap={4}>
+          {filteredMessages.map((message) => (
+            <GlassCard key={message.id} p={5}>
+              <Stack gap={3}>
+                <HStack justify="space-between" align="flex-start" gap={3} flexWrap="wrap">
+                  <Stack gap={1}>
+                    <HStack gap={2} flexWrap="wrap">
+                      <Heading size="sm">{message.counterpart}</Heading>
+                      {message.unread ? (
+                        <Badge bg="primary.50" color="primary.700">
+                          New
+                        </Badge>
+                      ) : null}
+                    </HStack>
+                    <Text fontSize="sm" color="muted">
+                      {message.taskTitle}
+                    </Text>
+                  </Stack>
+                  <Text fontSize="sm" color="muted">
+                    {formatDate(message.updatedAt)}
+                  </Text>
+                </HStack>
+                <Text fontSize="sm">{message.preview}</Text>
+              </Stack>
+            </GlassCard>
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,979 +1,370 @@
 'use client'
 
-import type { TasksQueryData } from '@/graphql/tasks-query.types'
-import { useQuery } from '@apollo/client/react'
-import { Box, Grid, GridItem, HStack, Link, Stack } from '@chakra-ui/react'
-import type { MeQuery } from '@codegen/schema'
-import { Badge, Button, DashboardShell, GlassCard, Heading, Text } from '@ui'
+import { Box, Grid, HStack, Link, SimpleGrid, Stack } from '@chakra-ui/react'
 import NextLink from 'next/link'
-import { useRouter } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
 
-import { ME_QUERY } from '@/graphql/auth'
-import { TASKS_QUERY } from '@/graphql/jobs'
-import { clearAuthToken } from '@/utils/auth'
-import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import { formatDate, formatPounds } from '@/features/dashboard/dashboardHelpers'
+import { Badge, Button, GlassCard, Heading, Text } from '@ui'
 
-type TaskItem = TasksQueryData['tasks']['items'][number]
-type TabKey = 'created' | 'quoted'
-
-function formatPounds(pricePence: number) {
-  return `£${(pricePence / 100).toFixed(0)}`
-}
-
-function timeFromUnknown(value: unknown): number {
-  const d =
-    typeof value === 'string' || typeof value === 'number'
-      ? new Date(value)
-      : value instanceof Date
-        ? value
-        : null
-  return d && !Number.isNaN(d.getTime()) ? d.getTime() : 0
-}
-
-function formatDate(iso: unknown) {
-  const d =
-    typeof iso === 'string' || typeof iso === 'number'
-      ? new Date(iso)
-      : iso instanceof Date
-        ? iso
-        : null
-  if (!d || Number.isNaN(d.getTime())) return '—'
-  return new Intl.DateTimeFormat('en-GB', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(d)
-}
-
-function formatRelativePosted(iso: unknown): string {
-  const ms = timeFromUnknown(iso)
-  if (!ms) return 'Recently'
-  const diff = Date.now() - ms
-  const minutes = Math.floor(diff / 60000)
-  if (minutes < 1) return 'Posted just now'
-  if (minutes < 60) return `Posted ${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `Posted ${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days === 1) return 'Posted yesterday'
-  if (days < 7) return `Posted ${days} days ago`
-  return `Posted ${formatDate(iso)}`
-}
-
-function isTaskCompleted(status: string) {
-  return /complete|done|closed|paid|archived|finished|resolved/i.test(
-    status.trim(),
-  )
-}
-
-function isOfferAwarded(status: string) {
-  return /accept|award|select|win|approved|chosen/i.test(status.trim())
-}
-
-function getOfferRange(offers: Array<{ pricePence: number }>) {
-  if (offers.length === 0) return null
-  const prices = offers.map((offer) => offer.pricePence)
-  const min = Math.min(...prices)
-  const max = Math.max(...prices)
-  return min === max
-    ? formatPounds(min)
-    : `${formatPounds(min)}–${formatPounds(max)}`
-}
-
-function getCategoryVisual(category: string | null | undefined) {
-  const key = (category ?? '').toLowerCase()
-  if (key.includes('plumb') || key.includes('water'))
-    return {
-      glyph: '🏠',
-      bg: 'linear-gradient(135deg, #d9e6ff 0%, #b5ceff 100%)',
-    }
-  if (key.includes('electr'))
-    return {
-      glyph: '🔌',
-      bg: 'linear-gradient(135deg, #dfe8f7 0%, #8fb4ff 100%)',
-    }
-  if (key.includes('paint') || key.includes('decor'))
-    return {
-      glyph: '🎨',
-      bg: 'linear-gradient(135deg, #fff4e4 0%, #ffddb8 100%)',
-    }
-  return {
-    glyph: '🔧',
-    bg: 'linear-gradient(135deg, #eef4ff 0%, #dfe8f7 100%)',
-  }
-}
-
-function matchesSearch(task: TaskItem, q: string) {
-  const s = q.trim().toLowerCase()
-  if (!s) return true
+function MetricCard({
+  label,
+  value,
+  helper,
+}: {
+  label: string
+  value: string
+  helper: string
+}) {
   return (
-    task.title.toLowerCase().includes(s) ||
-    (task.description ?? '').toLowerCase().includes(s) ||
-    (task.location ?? '').toLowerCase().includes(s)
-  )
-}
-
-function OfferAvatarStack({ count }: { count: number }) {
-  const shown = Math.min(count, 3)
-  const extra = count - shown
-  const letters = ['A', 'B', 'C'] as const
-  return (
-    <HStack gap={0}>
-      {letters.slice(0, shown).map((letter, i) => (
-        <Box
-          key={letter}
-          w={8}
-          h={8}
-          borderRadius="full"
-          bg="primary.200"
-          color="primary.800"
+    <GlassCard p={5}>
+      <Stack gap={2}>
+        <Text
           fontSize="10px"
           fontWeight={800}
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          borderWidth="2px"
-          borderColor="surfaceContainerLowest"
-          ml={i > 0 ? -2 : 0}
-          zIndex={shown - i}
-        >
-          {letter}
-        </Box>
-      ))}
-      {extra > 0 ? (
-        <Box
-          w={8}
-          h={8}
-          borderRadius="full"
-          bg="surfaceContainerHigh"
+          letterSpacing="0.08em"
           color="muted"
-          fontSize="xs"
-          fontWeight={700}
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          borderWidth="2px"
-          borderColor="surfaceContainerLowest"
-          ml={-2}
+          textTransform="uppercase"
         >
-          +{extra}
-        </Box>
-      ) : null}
-    </HStack>
+          {label}
+        </Text>
+        <Heading size="lg">{value}</Heading>
+        <Text fontSize="sm" color="muted">
+          {helper}
+        </Text>
+      </Stack>
+    </GlassCard>
   )
 }
 
-export default function DashboardPage() {
-  const router = useRouter()
-  const [tab, setTab] = useState<TabKey>('created')
-  const [search, setSearch] = useState('')
-
-  useEffect(() => {
-    const v = new URLSearchParams(window.location.search).get('view')
-    if (v === 'quotes') setTab('quoted')
-  }, [])
-
+export default function DashboardOverviewPage() {
   const {
-    data: meData,
-    loading: meLoading,
-    error: meError,
-    refetch: refetchMe,
-  } = useQuery<MeQuery>(ME_QUERY, {
-    fetchPolicy: 'network-only',
-  })
-  const me = meData?.me ?? null
-  const {
-    data: tasksData,
-    loading: tasksLoading,
-    error: tasksError,
-    refetch: refetchTasks,
-  } = useQuery<TasksQueryData>(TASKS_QUERY, {
-    fetchPolicy: 'network-only',
-    skip: !me,
-  })
-  const tasks = tasksData?.tasks.items ?? []
-  const meErrorMessage = meError
-    ? getFriendlyErrorMessage(meError, 'Could not load account details.')
-    : null
-  const tasksErrorMessage = tasksError
-    ? getFriendlyErrorMessage(tasksError, 'Could not load tasks.')
-    : null
+    tasksLoading,
+    tasksErrorMessage,
+    displayName,
+    workerEnabled,
+    profile,
+    workerProfile,
+    activePostedTasks,
+    customerBookings,
+    myOffers,
+    offerCountOnMyTasks,
+    serviceHistory,
+    messages,
+    totalSpendPence,
+    totalEarningsPence,
+  } = useDashboardData()
 
-  const { myPostedTasks, myOffers, offerCountOnMyTasks } = useMemo(() => {
-    if (!me) {
-      return {
-        myPostedTasks: [] as TaskItem[],
-        myOffers: [] as Array<{
-          task: TaskItem
-          offer: TaskItem['offers'][number]
-        }>,
-        offerCountOnMyTasks: 0,
-      }
-    }
-
-    const posted = tasks
-      .filter((task) => task.createdByUserId === me.id)
-      .sort(
-        (a, b) => timeFromUnknown(b.createdAt) - timeFromUnknown(a.createdAt),
-      )
-    const submitted = tasks
-      .flatMap((task) =>
-        task.offers
-          .filter((offer) => offer.workerUserId === me.id)
-          .map((offer) => ({ task, offer })),
-      )
-      .sort(
-        (a, b) =>
-          timeFromUnknown(b.offer.createdAt) -
-          timeFromUnknown(a.offer.createdAt),
-      )
-
-    const offerCount = posted.reduce(
-      (count, task) => count + task.offers.length,
-      0,
-    )
-
-    return {
-      myPostedTasks: posted,
-      myOffers: submitted,
-      offerCountOnMyTasks: offerCount,
-    }
-  }, [tasks, me])
-
-  const activePosted = useMemo(
-    () =>
-      myPostedTasks.filter(
-        (t) => !isTaskCompleted(t.status) && matchesSearch(t, search),
-      ),
-    [myPostedTasks, search],
-  )
-
-  const quotedFiltered = useMemo(
-    () => myOffers.filter(({ task }) => matchesSearch(task, search)),
-    [myOffers, search],
-  )
-
-  const completedAsPoster = useMemo(
-    () => myPostedTasks.filter((t) => isTaskCompleted(t.status)),
-    [myPostedTasks],
-  )
-
-  const completedAsWorker = useMemo(
-    () => myOffers.filter(({ task }) => isTaskCompleted(task.status)),
-    [myOffers],
-  )
-
-  const completedHistoryItems = useMemo(() => {
-    const poster = completedAsPoster.map((t) => ({
-      kind: 'poster' as const,
-      task: t,
-      at: timeFromUnknown(t.createdAt),
-    }))
-    const worker = completedAsWorker.map(({ task, offer }) => ({
-      kind: 'worker' as const,
-      task,
-      offer,
-      at: timeFromUnknown(offer.createdAt),
-    }))
-    return [...poster, ...worker].sort((a, b) => b.at - a.at).slice(0, 6)
-  }, [completedAsPoster, completedAsWorker])
-
-  const totalSpendPence = useMemo(
-    () =>
-      completedAsPoster.reduce((sum, t) => sum + (t.priceOfferPence ?? 0), 0),
-    [completedAsPoster],
-  )
-
-  const quotesInProgress = useMemo(
-    () =>
-      myOffers.filter(({ task }) => !isTaskCompleted(task.status)).slice(0, 4),
-    [myOffers],
-  )
-
-  const userInitial = me?.email?.trim()?.charAt(0)?.toUpperCase() ?? '?'
-
-  if (!meLoading && !me) {
-    return (
-      <Box bg="bg" color="fg" minH="100vh" py={{ base: 8, md: 12 }} px={4}>
-        <Stack gap={8} maxW="lg" mx="auto">
-          <Box>
-            <Heading size="lg">Dashboard</Heading>
-            <Text color="muted" mt={2}>
-              Manage your posted tasks and quotes in one place.
-            </Text>
-          </Box>
-          {meErrorMessage ? (
-            <Text color="red.400" fontSize="sm">
-              {meErrorMessage}
-            </Text>
-          ) : null}
-          <GlassCard p={6}>
-            <Stack gap={4}>
-              <Heading size="md">Sign in to view your dashboard</Heading>
-              <Text color="muted">
-                You need an account to manage your posted tasks and quotes.
-              </Text>
-              <HStack gap={3} flexWrap="wrap">
-                <Button as={NextLink} href="/login">
-                  Log in
-                </Button>
-                <Button as={NextLink} href="/register" variant="subtle">
-                  Register
-                </Button>
-              </HStack>
-            </Stack>
-          </GlassCard>
-          <HStack gap={4} flexWrap="wrap">
-            <Link
-              as={NextLink}
-              href="/"
-              fontSize="sm"
-              color="muted"
-              _hover={{ color: 'fg' }}
-            >
-              ← Back to home
-            </Link>
-          </HStack>
-        </Stack>
-      </Box>
-    )
-  }
+  const unreadCount = messages.filter((message) => message.unread).length
+  const recentMessages = messages.slice(0, 3)
+  const recentHistory = serviceHistory.slice(0, 3)
 
   return (
-    <DashboardShell
-      activeNav="my-jobs"
-      searchValue={search}
-      onSearchChange={setSearch}
-      userLabel={me?.email ?? 'Account'}
-      userInitial={userInitial}
-    >
-      <Stack gap={10}>
-        {meLoading ? <Text color="muted">Loading account…</Text> : null}
-        {meErrorMessage ? (
-          <Text color="red.400" fontSize="sm">
-            {meErrorMessage}
-          </Text>
-        ) : null}
-
-        {me ? (
-          <>
-            <Stack gap={4}>
-              <HStack
-                justify="space-between"
-                align={{ base: 'flex-start', md: 'center' }}
-                flexDir={{ base: 'column', md: 'row' }}
-                gap={4}
+    <Stack gap={8}>
+      <Grid templateColumns={{ base: '1fr', xl: '1.5fr 1fr' }} gap={6}>
+        <GlassCard
+          p={{ base: 6, md: 7 }}
+          bg="linear-gradient(160deg, #f7f9ff 0%, #ffffff 100%)"
+        >
+          <Stack gap={5}>
+            <Badge alignSelf="flex-start">Dashboard overview</Badge>
+            <Stack gap={2}>
+              <Heading size="xl">Welcome back, {displayName}.</Heading>
+              <Text color="muted" maxW="3xl">
+                Track the jobs you have posted, monitor booking progress, and
+                unlock the worker flow when you are ready to send quotes.
+              </Text>
+            </Stack>
+            <HStack gap={3} flexWrap="wrap">
+              <Button as={NextLink} href="/dashboard/jobs">
+                Review my jobs
+              </Button>
+              <Button as={NextLink} href="/tasks/create" variant="subtle">
+                Post a new job
+              </Button>
+              <Button
+                as={NextLink}
+                href={workerEnabled ? '/dashboard/quotes' : '/dashboard/worker/register'}
+                variant="outline"
               >
-                <Stack gap={2} maxW="3xl">
-                  <Heading size="xl">My Jobs</Heading>
-                  <Text color="muted" fontSize="md">
-                    Manage your active projects, track offers, and respond to
-                    quote requests—all in one architectural view.
-                  </Text>
-                </Stack>
-                <Button as={NextLink} href="/tasks/create" flexShrink={0}>
-                  + Post a New Job
-                </Button>
-              </HStack>
+                {workerEnabled ? 'Open worker tools' : 'Become a worker'}
+              </Button>
+            </HStack>
+            <HStack gap={3} flexWrap="wrap">
+              <Badge bg="surfaceContainerHigh" color="fg">
+                {profile.location || 'Location not set'}
+              </Badge>
+              <Badge bg="primary.50" color="primary.700">
+                {workerEnabled ? 'Worker unlocked' : 'Customer mode'}
+              </Badge>
+            </HStack>
+          </Stack>
+        </GlassCard>
 
-              <HStack gap={3} flexWrap="wrap" justify="space-between">
-                <HStack
-                  gap={0}
-                  p={1}
+        <SimpleGrid columns={{ base: 1, sm: 2, xl: 1 }} gap={4}>
+          <MetricCard
+            label="Active jobs"
+            value={String(activePostedTasks.length)}
+            helper="Posted jobs currently visible to professionals."
+          />
+          <MetricCard
+            label="Quotes received"
+            value={String(offerCountOnMyTasks)}
+            helper="Offers collected against your current job briefs."
+          />
+          <MetricCard
+            label="History value"
+            value={formatPounds(totalSpendPence)}
+            helper="Completed spend recorded in your customer history."
+          />
+          <MetricCard
+            label="Worker earnings"
+            value={workerEnabled ? formatPounds(totalEarningsPence) : 'Locked'}
+            helper={
+              workerEnabled
+                ? 'Awarded worker quotes tracked in your earnings workspace.'
+                : 'Activate your worker profile to start tracking payouts.'
+            }
+          />
+        </SimpleGrid>
+      </Grid>
+
+      {tasksLoading ? <Text color="muted">Loading task activity…</Text> : null}
+      {tasksErrorMessage ? (
+        <Text color="red.400" fontSize="sm">
+          {tasksErrorMessage}
+        </Text>
+      ) : null}
+
+      <Grid templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }} gap={6}>
+        <GlassCard p={6}>
+          <Stack gap={4}>
+            <HStack justify="space-between" align="flex-start" gap={3} flexWrap="wrap">
+              <Stack gap={1}>
+                <Heading size="md">Bookings & live job activity</Heading>
+                <Text color="muted" fontSize="sm">
+                  Your open tasks and the jobs with active quote activity.
+                </Text>
+              </Stack>
+              <Link
+                as={NextLink}
+                href="/dashboard/jobs"
+                fontWeight={700}
+                color="primary.600"
+                _hover={{ color: 'primary.700' }}
+              >
+                View all jobs
+              </Link>
+            </HStack>
+            {activePostedTasks.length === 0 ? (
+              <Text color="muted" fontSize="sm">
+                No active jobs yet. Post a job to start collecting quotes from
+                trusted tradespeople.
+              </Text>
+            ) : (
+              <Stack gap={3}>
+                {activePostedTasks.slice(0, 3).map((task) => (
+                  <GlassCard
+                    key={task.id}
+                    p={4}
+                    bg="surfaceContainerLow"
+                    borderWidth="1px"
+                    borderColor="border"
+                  >
+                    <Stack gap={2}>
+                      <HStack justify="space-between" gap={3} flexWrap="wrap">
+                        <Heading size="sm">{task.title}</Heading>
+                        <Badge
+                          bg={task.offers.length > 0 ? 'secondaryFixed' : 'surfaceContainerHigh'}
+                          color={task.offers.length > 0 ? 'onSecondaryFixed' : 'fg'}
+                        >
+                          {task.offers.length > 0
+                            ? `${task.offers.length} quotes`
+                            : 'Awaiting quotes'}
+                        </Badge>
+                      </HStack>
+                      <Text fontSize="sm" color="muted">
+                        {task.location ?? 'Location TBC'}
+                      </Text>
+                      <HStack gap={3} flexWrap="wrap">
+                        <Link
+                          as={NextLink}
+                          href={`/task/${task.id}`}
+                          color="primary.600"
+                          fontWeight={700}
+                          _hover={{ color: 'primary.700' }}
+                        >
+                          Open job
+                        </Link>
+                        <Text fontSize="sm" color="muted">
+                          {task.offers.length > 0
+                            ? 'Booking activity is visible on the job detail page.'
+                            : 'Share the job brief to attract more professionals.'}
+                        </Text>
+                      </HStack>
+                    </Stack>
+                  </GlassCard>
+                ))}
+              </Stack>
+            )}
+            {customerBookings.length > 0 ? (
+              <Text fontSize="sm" color="muted">
+                {customerBookings.length} of your jobs already have active
+                quote/booking movement.
+              </Text>
+            ) : null}
+          </Stack>
+        </GlassCard>
+
+        <GlassCard
+          p={6}
+          bg={workerEnabled ? 'surfaceContainerLow' : 'primary.50'}
+          borderWidth="1px"
+          borderColor={workerEnabled ? 'border' : 'primary.100'}
+        >
+          <Stack gap={4}>
+            <Heading size="md">
+              {workerEnabled ? 'Worker profile live' : 'Unlock worker mode'}
+            </Heading>
+            <Text color="muted" fontSize="sm">
+              {workerEnabled
+                ? 'Your worker workspace is active. Use it to send quotes, manage incoming work, and monitor earnings.'
+                : 'Worker features are blocked by default. Create your worker profile to unlock quoting and earnings.'}
+            </Text>
+            <Stack gap={2}>
+              <HStack justify="space-between">
+                <Text color="muted" fontSize="sm">
+                  Skills
+                </Text>
+                <Text fontWeight={700} fontSize="sm">
+                  {workerEnabled
+                    ? workerProfile.skills.join(', ') || 'Add skills'
+                    : `${profile.preferredTrades.length} saved`}
+                </Text>
+              </HStack>
+              <HStack justify="space-between">
+                <Text color="muted" fontSize="sm">
+                  Quotes sent
+                </Text>
+                <Text fontWeight={700} fontSize="sm">
+                  {String(myOffers.length)}
+                </Text>
+              </HStack>
+              <HStack justify="space-between">
+                <Text color="muted" fontSize="sm">
+                  Status
+                </Text>
+                <Text fontWeight={700} fontSize="sm">
+                  {workerEnabled ? 'Active' : 'Locked'}
+                </Text>
+              </HStack>
+            </Stack>
+            <Button
+              as={NextLink}
+              href={workerEnabled ? '/dashboard/quotes' : '/dashboard/worker/register'}
+            >
+              {workerEnabled ? 'Go to worker tools' : 'Become a worker'}
+            </Button>
+          </Stack>
+        </GlassCard>
+      </Grid>
+
+      <Grid templateColumns={{ base: '1fr', xl: '1fr 1fr' }} gap={6}>
+        <GlassCard p={6}>
+          <Stack gap={4}>
+            <HStack justify="space-between" gap={3} flexWrap="wrap">
+              <Stack gap={1}>
+                <Heading size="md">Recent messages</Heading>
+                <Text color="muted" fontSize="sm">
+                  Job updates, worker onboarding notes, and scheduling nudges.
+                </Text>
+              </Stack>
+              <Badge bg="surfaceContainerHigh" color="fg">
+                {unreadCount} unread
+              </Badge>
+            </HStack>
+            <Stack gap={3}>
+              {recentMessages.map((message) => (
+                <GlassCard
+                  key={message.id}
+                  p={4}
                   bg="surfaceContainerLow"
-                  borderRadius="full"
                   borderWidth="1px"
                   borderColor="border"
                 >
-                  <Button
-                    size="sm"
-                    variant={tab === 'created' ? 'solid' : 'ghost'}
-                    borderRadius="full"
-                    px={5}
-                    onClick={() => setTab('created')}
-                  >
-                    Jobs I&apos;ve Created
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant={tab === 'quoted' ? 'solid' : 'ghost'}
-                    borderRadius="full"
-                    px={5}
-                    onClick={() => setTab('quoted')}
-                  >
-                    Jobs I&apos;ve Quoted
-                  </Button>
-                </HStack>
-                <HStack gap={2} flexWrap="wrap">
-                  <Button
-                    size="sm"
-                    variant="subtle"
-                    onClick={() => {
-                      clearAuthToken()
-                      router.push('/login')
-                    }}
-                  >
-                    Log out
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      void refetchMe()
-                      void refetchTasks()
-                    }}
-                  >
-                    Refresh
-                  </Button>
-                </HStack>
-              </HStack>
-            </Stack>
-
-            <Grid
-              templateColumns={{ base: '1fr', xl: '1fr 340px' }}
-              gap={{ base: 8, xl: 8 }}
-              alignItems="start"
-            >
-              <GridItem>
-                <Stack gap={8}>
-                  {tab === 'created' ? (
-                    <Stack gap={4}>
-                      <HStack gap={3} flexWrap="wrap" align="center">
-                        <Heading size="md">Active Listings</Heading>
-                        <Badge
-                          px={3}
-                          py={1}
-                          borderRadius="full"
-                          bg="primary.100"
-                          color="primary.800"
-                          fontSize="xs"
-                          fontWeight={800}
-                          letterSpacing="0.04em"
-                        >
-                          {activePosted.length} ACTIVE
+                  <Stack gap={1}>
+                    <HStack justify="space-between" gap={3} flexWrap="wrap">
+                      <Heading size="sm">{message.counterpart}</Heading>
+                      {message.unread ? (
+                        <Badge bg="primary.50" color="primary.700">
+                          New
                         </Badge>
-                      </HStack>
-
-                      {tasksLoading ? (
-                        <Text color="muted">Loading tasks…</Text>
                       ) : null}
-                      {tasksErrorMessage ? (
-                        <Text color="red.400" fontSize="sm">
-                          {tasksErrorMessage}
-                        </Text>
-                      ) : null}
-
-                      {!tasksLoading && !tasksError ? (
-                        activePosted.length === 0 ? (
-                          <GlassCard p={6}>
-                            <Text color="muted">
-                              No active listings. Post a job to get offers from
-                              verified craftspeople.
-                            </Text>
-                          </GlassCard>
-                        ) : (
-                          <Stack gap={4}>
-                            {activePosted.map((task) => {
-                              const visual = getCategoryVisual(task.category)
-                              const n = task.offers.length
-                              return (
-                                <GlassCard key={task.id} p={5}>
-                                  <Stack gap={4}>
-                                    <HStack
-                                      align="flex-start"
-                                      gap={4}
-                                      flexWrap="wrap"
-                                    >
-                                      <Box
-                                        w={14}
-                                        h={14}
-                                        borderRadius="lg"
-                                        bg={visual.bg}
-                                        display="flex"
-                                        alignItems="center"
-                                        justifyContent="center"
-                                        fontSize="xl"
-                                        flexShrink={0}
-                                      >
-                                        {visual.glyph}
-                                      </Box>
-                                      <Stack gap={1} flex="1" minW="200px">
-                                        <Heading size="sm">
-                                          {task.title}
-                                        </Heading>
-                                        <HStack gap={2} flexWrap="wrap">
-                                          {task.location ? (
-                                            <Text fontSize="sm" color="muted">
-                                              {task.location}
-                                            </Text>
-                                          ) : null}
-                                          <Text fontSize="sm" color="muted">
-                                            {formatRelativePosted(
-                                              task.createdAt,
-                                            )}
-                                          </Text>
-                                        </HStack>
-                                      </Stack>
-                                      <Stack
-                                        gap={3}
-                                        align={{
-                                          base: 'flex-start',
-                                          sm: 'flex-end',
-                                        }}
-                                      >
-                                        <HStack gap={2} flexWrap="wrap">
-                                          {n > 0 ? (
-                                            <Badge
-                                              px={2}
-                                              py={1}
-                                              borderRadius="md"
-                                              bg="secondaryFixed"
-                                              color="onSecondaryFixed"
-                                              fontSize="10px"
-                                              fontWeight={800}
-                                              letterSpacing="0.06em"
-                                            >
-                                              {n} OFFER{n === 1 ? '' : 'S'}{' '}
-                                              RECEIVED
-                                            </Badge>
-                                          ) : (
-                                            <Badge
-                                              px={2}
-                                              py={1}
-                                              borderRadius="md"
-                                              bg="surfaceContainerHigh"
-                                              color="muted"
-                                              fontSize="10px"
-                                              fontWeight={800}
-                                              letterSpacing="0.06em"
-                                            >
-                                              AWAITING QUOTES
-                                            </Badge>
-                                          )}
-                                          {n > 0 ? (
-                                            <OfferAvatarStack count={n} />
-                                          ) : null}
-                                        </HStack>
-                                        <Button
-                                          as={NextLink}
-                                          href={`/task/${task.id}`}
-                                          size="sm"
-                                          alignSelf={{ sm: 'flex-end' }}
-                                        >
-                                          {n > 0 ? 'View Offers' : 'View Job'}
-                                        </Button>
-                                      </Stack>
-                                    </HStack>
-
-                                    {n === 0 ? (
-                                      <Text fontSize="sm" color="muted">
-                                        No offers yet. Share your listing to
-                                        reach more pros, or{' '}
-                                        <Link
-                                          as={NextLink}
-                                          href={`/task/${task.id}`}
-                                          color="primary.600"
-                                          fontWeight={700}
-                                          _hover={{ color: 'primary.700' }}
-                                        >
-                                          boost visibility
-                                        </Link>
-                                        .
-                                      </Text>
-                                    ) : null}
-
-                                    {getOfferRange(task.offers) ? (
-                                      <Text fontSize="xs" color="muted">
-                                        Offer range:{' '}
-                                        {getOfferRange(task.offers)}
-                                      </Text>
-                                    ) : null}
-                                  </Stack>
-                                </GlassCard>
-                              )
-                            })}
-                          </Stack>
-                        )
-                      ) : null}
-                    </Stack>
-                  ) : (
-                    <Stack gap={4}>
-                      <HStack gap={3} flexWrap="wrap" align="center">
-                        <Heading size="md">Your quoted jobs</Heading>
-                        <Badge
-                          px={3}
-                          py={1}
-                          borderRadius="full"
-                          bg="surfaceContainerHigh"
-                          color="fg"
-                          fontSize="xs"
-                          fontWeight={800}
-                        >
-                          {quotedFiltered.length} QUOTES
-                        </Badge>
-                      </HStack>
-                      {tasksLoading ? (
-                        <Text color="muted">Loading…</Text>
-                      ) : null}
-                      {!tasksLoading && !tasksError ? (
-                        quotedFiltered.length === 0 ? (
-                          <GlassCard p={6}>
-                            <Text color="muted">
-                              You have not submitted any quotes yet. Browse open
-                              jobs and send your first offer.
-                            </Text>
-                            <Button
-                              as={NextLink}
-                              href="/tasks"
-                              variant="tool"
-                              mt={4}
-                              size="sm"
-                            >
-                              Browse tasks
-                            </Button>
-                          </GlassCard>
-                        ) : (
-                          <Stack gap={4}>
-                            {quotedFiltered.map(({ task, offer }) => {
-                              const visual = getCategoryVisual(task.category)
-                              const awarded = isOfferAwarded(offer.status)
-                              return (
-                                <GlassCard key={offer.id} p={5}>
-                                  <HStack
-                                    align="flex-start"
-                                    gap={4}
-                                    flexWrap="wrap"
-                                  >
-                                    <Box
-                                      w={14}
-                                      h={14}
-                                      borderRadius="lg"
-                                      bg={visual.bg}
-                                      display="flex"
-                                      alignItems="center"
-                                      justifyContent="center"
-                                      fontSize="xl"
-                                      flexShrink={0}
-                                    >
-                                      {visual.glyph}
-                                    </Box>
-                                    <Stack gap={2} flex="1" minW="200px">
-                                      <Heading size="sm">{task.title}</Heading>
-                                      <Text fontSize="sm" color="muted">
-                                        {task.location ?? 'Location TBC'} ·{' '}
-                                        {formatPounds(offer.pricePence)} offer ·{' '}
-                                        {formatRelativePosted(offer.createdAt)}
-                                      </Text>
-                                      <Badge
-                                        alignSelf="flex-start"
-                                        px={2}
-                                        py={1}
-                                        borderRadius="md"
-                                        bg={
-                                          awarded
-                                            ? 'secondaryFixed'
-                                            : 'surfaceContainerHigh'
-                                        }
-                                        color={
-                                          awarded ? 'onSecondaryFixed' : 'muted'
-                                        }
-                                        fontSize="10px"
-                                        fontWeight={800}
-                                        letterSpacing="0.06em"
-                                      >
-                                        {awarded ? 'AWARDED' : 'PENDING'}
-                                      </Badge>
-                                    </Stack>
-                                    <Button
-                                      as={NextLink}
-                                      href={`/task/${task.id}`}
-                                      size="sm"
-                                      variant="subtle"
-                                    >
-                                      View task
-                                    </Button>
-                                  </HStack>
-                                </GlassCard>
-                              )
-                            })}
-                          </Stack>
-                        )
-                      ) : null}
-                    </Stack>
-                  )}
-                </Stack>
-              </GridItem>
-
-              <GridItem>
-                <Stack gap={4} position={{ xl: 'sticky' }} top={{ xl: 4 }}>
-                  <Box
-                    borderRadius="xl"
-                    bg="linear-gradient(160deg, #03225a 0%, #012b73 55%, #00358f 100%)"
-                    color="white"
-                    p={6}
-                    boxShadow="card"
-                  >
-                    <Stack gap={4}>
-                      <Stack gap={1}>
-                        <Text fontSize="sm" opacity={0.85}>
-                          Total spend (completed)
-                        </Text>
-                        <Heading size="lg" color="white">
-                          {formatPounds(totalSpendPence)}
-                        </Heading>
-                      </Stack>
-                      <Stack gap={1}>
-                        <Text fontSize="sm" opacity={0.85}>
-                          Completed jobs
-                        </Text>
-                        <Heading size="md" color="white">
-                          {completedAsPoster.length}
-                        </Heading>
-                      </Stack>
-                      <Box
-                        borderWidth="1px"
-                        borderStyle="dashed"
-                        borderColor="rgba(255,255,255,0.35)"
-                        borderRadius="lg"
-                        p={4}
-                      >
-                        <Text
-                          fontSize="10px"
-                          fontWeight={800}
-                          letterSpacing="0.1em"
-                          opacity={0.9}
-                          mb={2}
-                        >
-                          ⭐ MASTER STATUS
-                        </Text>
-                        <Text fontSize="sm" lineHeight="tall" opacity={0.92}>
-                          You&apos;re in the top tier of homeowners. Complete
-                          profiles and clear briefs get faster responses from
-                          pros.
-                        </Text>
-                      </Box>
-                    </Stack>
-                  </Box>
-
-                  <GlassCard p={5} bg="primary.50" borderColor="primary.100">
-                    <Stack gap={4}>
-                      <Text
-                        fontSize="xs"
-                        fontWeight={800}
-                        letterSpacing="0.1em"
-                        color="primary.800"
-                      >
-                        QUOTES IN PROGRESS
-                      </Text>
-                      {quotesInProgress.length === 0 ? (
-                        <Text fontSize="sm" color="muted">
-                          No open quotes right now.
-                        </Text>
-                      ) : (
-                        <Stack gap={3}>
-                          {quotesInProgress.map(({ task, offer }) => {
-                            const awarded = isOfferAwarded(offer.status)
-                            return (
-                              <HStack
-                                key={offer.id}
-                                justify="space-between"
-                                align="flex-start"
-                                gap={2}
-                              >
-                                <Stack gap={0}>
-                                  <Text fontWeight={700} fontSize="sm">
-                                    {task.title}
-                                  </Text>
-                                  <Text fontSize="xs" color="muted">
-                                    {formatPounds(offer.pricePence)} offer
-                                  </Text>
-                                </Stack>
-                                <Badge
-                                  px={2}
-                                  py={0.5}
-                                  fontSize="10px"
-                                  fontWeight={800}
-                                  bg={
-                                    awarded
-                                      ? 'secondaryFixed'
-                                      : 'surfaceContainerHigh'
-                                  }
-                                  color={awarded ? 'onSecondaryFixed' : 'muted'}
-                                >
-                                  {awarded ? 'AWARDED' : 'PENDING'}
-                                </Badge>
-                              </HStack>
-                            )
-                          })}
-                        </Stack>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        color="primary.700"
-                        onClick={() => setTab('quoted')}
-                      >
-                        View all quoted jobs
-                      </Button>
-                    </Stack>
-                  </GlassCard>
-
-                  <GlassCard p={5}>
-                    <Stack gap={2} fontSize="sm">
-                      <Text fontWeight={700}>At a glance</Text>
-                      <HStack justify="space-between">
-                        <Text color="muted">Posted tasks</Text>
-                        <Text fontWeight={700}>{myPostedTasks.length}</Text>
-                      </HStack>
-                      <HStack justify="space-between">
-                        <Text color="muted">Offers on your tasks</Text>
-                        <Text fontWeight={700}>{offerCountOnMyTasks}</Text>
-                      </HStack>
-                      <HStack justify="space-between">
-                        <Text color="muted">Quotes you sent</Text>
-                        <Text fontWeight={700}>{myOffers.length}</Text>
-                      </HStack>
-                    </Stack>
-                  </GlassCard>
-                </Stack>
-              </GridItem>
-            </Grid>
-
-            <Stack gap={4}>
-              <Heading size="lg">Completed History</Heading>
-              {completedHistoryItems.length === 0 ? (
-                <GlassCard p={6}>
-                  <Text color="muted">
-                    Completed work will appear here once jobs are marked done.
-                  </Text>
+                    </HStack>
+                    <Text fontSize="sm" color="muted">
+                      {message.taskTitle}
+                    </Text>
+                    <Text fontSize="sm">{message.preview}</Text>
+                  </Stack>
                 </GlassCard>
-              ) : (
-                <Box
-                  overflowX="auto"
-                  pb={2}
-                  css={{
-                    scrollbarWidth: 'thin',
-                  }}
-                >
-                  <HStack align="stretch" gap={4} minW="min-content">
-                    {completedHistoryItems.slice(0, 2).map((item) => {
-                      const task = item.task
-                      const headline =
-                        item.kind === 'poster' ? 'Posted job' : 'Your quote'
-                      return (
-                        <GlassCard
-                          key={`${item.kind}-${task.id}`}
-                          p={5}
-                          minW="280px"
-                          maxW="320px"
-                          bg="surfaceContainerLow"
-                          flexShrink={0}
-                        >
-                          <Stack gap={3}>
-                            <HStack gap={2}>
-                              <Text fontSize="lg">✓</Text>
-                              <Text
-                                fontSize="10px"
-                                fontWeight={800}
-                                letterSpacing="0.08em"
-                                color="muted"
-                              >
-                                {formatDate(task.createdAt).toUpperCase()}
-                              </Text>
-                            </HStack>
-                            <Heading size="sm">{task.title}</Heading>
-                            <Text
-                              fontSize="sm"
-                              color="muted"
-                              css={{
-                                display: '-webkit-box',
-                                WebkitLineClamp: 2,
-                                WebkitBoxOrient: 'vertical',
-                                overflow: 'hidden',
-                              }}
-                            >
-                              {task.description}
-                            </Text>
-                            <HStack justify="space-between" pt={2}>
-                              <Text fontWeight={800}>
-                                {task.priceOfferPence
-                                  ? formatPounds(task.priceOfferPence)
-                                  : '—'}
-                              </Text>
-                              <Link
-                                as={NextLink}
-                                href={`/task/${task.id}`}
-                                fontSize="sm"
-                                fontWeight={700}
-                                color="primary.600"
-                                _hover={{ color: 'primary.700' }}
-                              >
-                                View invoice
-                              </Link>
-                            </HStack>
-                            <Text fontSize="xs" color="muted">
-                              {headline}
-                            </Text>
-                          </Stack>
-                        </GlassCard>
-                      )
-                    })}
-                    <GlassCard
-                      p={5}
-                      minW="240px"
-                      maxW="280px"
-                      flexShrink={0}
-                      bg="surfaceContainerHigh"
-                      display="flex"
-                      alignItems="center"
-                      justifyContent="center"
-                    >
-                      <Stack gap={3} textAlign="center" align="center">
-                        <Text fontSize="2xl">📄</Text>
-                        <Heading size="sm">Tax &amp; records</Heading>
-                        <Text fontSize="xs" color="muted">
-                          Export a summary of completed work for your records.
-                        </Text>
-                        <Link
-                          href="#"
-                          fontSize="xs"
-                          fontWeight={800}
-                          letterSpacing="0.06em"
-                          color="primary.600"
-                          onClick={(e) => e.preventDefault()}
-                        >
-                          DOWNLOAD SUMMARY
-                        </Link>
-                      </Stack>
-                    </GlassCard>
-                  </HStack>
-                </Box>
-              )}
+              ))}
             </Stack>
+            <Link
+              as={NextLink}
+              href="/dashboard/messages"
+              color="primary.600"
+              fontWeight={700}
+              _hover={{ color: 'primary.700' }}
+            >
+              Open message centre
+            </Link>
+          </Stack>
+        </GlassCard>
 
-            <HStack gap={4} flexWrap="wrap" pt={4}>
+        <GlassCard p={6}>
+          <Stack gap={4}>
+            <HStack justify="space-between" gap={3} flexWrap="wrap">
+              <Stack gap={1}>
+                <Heading size="md">Service history</Heading>
+                <Text color="muted" fontSize="sm">
+                  Completed jobs, archived bookings, and record-keeping.
+                </Text>
+              </Stack>
               <Link
                 as={NextLink}
-                href="/"
-                fontSize="sm"
-                color="muted"
-                _hover={{ color: 'fg' }}
+                href="/dashboard/history"
+                fontWeight={700}
+                color="primary.600"
+                _hover={{ color: 'primary.700' }}
               >
-                ← Back to home
-              </Link>
-              <Link
-                as={NextLink}
-                href="/tasks"
-                fontSize="sm"
-                color="muted"
-                _hover={{ color: 'fg' }}
-              >
-                Browse tasks →
+                View full history
               </Link>
             </HStack>
-          </>
-        ) : null}
-      </Stack>
-    </DashboardShell>
+            <Stack gap={3}>
+              {recentHistory.map((entry) => (
+                <GlassCard
+                  key={entry.id}
+                  p={4}
+                  bg="surfaceContainerLow"
+                  borderWidth="1px"
+                  borderColor="border"
+                >
+                  <Stack gap={1}>
+                    <HStack justify="space-between" gap={3} flexWrap="wrap">
+                      <Heading size="sm">{entry.title}</Heading>
+                      <Text fontWeight={800}>{formatPounds(entry.valuePence)}</Text>
+                    </HStack>
+                    <Text fontSize="sm" color="muted">
+                      {entry.location} · {formatDate(entry.completedAt)}
+                    </Text>
+                    <Text fontSize="sm">{entry.summary}</Text>
+                  </Stack>
+                </GlassCard>
+              ))}
+            </Stack>
+          </Stack>
+        </GlassCard>
+      </Grid>
+    </Stack>
   )
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -84,7 +84,11 @@ export default function DashboardOverviewPage() {
               </Button>
               <Button
                 as={NextLink}
-                href={workerEnabled ? '/dashboard/quotes' : '/dashboard/worker/register'}
+                href={
+                  workerEnabled
+                    ? '/dashboard/quotes'
+                    : '/dashboard/worker/register'
+                }
                 variant="outline"
               >
                 {workerEnabled ? 'Open worker tools' : 'Become a worker'}
@@ -139,7 +143,12 @@ export default function DashboardOverviewPage() {
       <Grid templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }} gap={6}>
         <GlassCard p={6}>
           <Stack gap={4}>
-            <HStack justify="space-between" align="flex-start" gap={3} flexWrap="wrap">
+            <HStack
+              justify="space-between"
+              align="flex-start"
+              gap={3}
+              flexWrap="wrap"
+            >
               <Stack gap={1}>
                 <Heading size="md">Bookings & live job activity</Heading>
                 <Text color="muted" fontSize="sm">
@@ -175,8 +184,14 @@ export default function DashboardOverviewPage() {
                       <HStack justify="space-between" gap={3} flexWrap="wrap">
                         <Heading size="sm">{task.title}</Heading>
                         <Badge
-                          bg={task.offers.length > 0 ? 'secondaryFixed' : 'surfaceContainerHigh'}
-                          color={task.offers.length > 0 ? 'onSecondaryFixed' : 'fg'}
+                          bg={
+                            task.offers.length > 0
+                              ? 'secondaryFixed'
+                              : 'surfaceContainerHigh'
+                          }
+                          color={
+                            task.offers.length > 0 ? 'onSecondaryFixed' : 'fg'
+                          }
                         >
                           {task.offers.length > 0
                             ? `${task.offers.length} quotes`
@@ -261,7 +276,11 @@ export default function DashboardOverviewPage() {
             </Stack>
             <Button
               as={NextLink}
-              href={workerEnabled ? '/dashboard/quotes' : '/dashboard/worker/register'}
+              href={
+                workerEnabled
+                  ? '/dashboard/quotes'
+                  : '/dashboard/worker/register'
+              }
             >
               {workerEnabled ? 'Go to worker tools' : 'Become a worker'}
             </Button>
@@ -352,7 +371,9 @@ export default function DashboardOverviewPage() {
                   <Stack gap={1}>
                     <HStack justify="space-between" gap={3} flexWrap="wrap">
                       <Heading size="sm">{entry.title}</Heading>
-                      <Text fontWeight={800}>{formatPounds(entry.valuePence)}</Text>
+                      <Text fontWeight={800}>
+                        {formatPounds(entry.valuePence)}
+                      </Text>
                     </HStack>
                     <Text fontSize="sm" color="muted">
                       {entry.location} · {formatDate(entry.completedAt)}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -3,11 +3,11 @@
 import { Grid, HStack, Stack, Textarea } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
 
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
 import {
   DASHBOARD_TRADE_OPTIONS,
   type DashboardTrade,
 } from '@/features/dashboard/dashboardDemo'
-import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
 import { Badge, Button, GlassCard, Heading, Text, TextInput } from '@ui'
 
 export default function DashboardProfilePage() {
@@ -17,7 +17,9 @@ export default function DashboardProfilePage() {
   const [phoneNumber, setPhoneNumber] = useState(profile.phoneNumber)
   const [location, setLocation] = useState(profile.location)
   const [bio, setBio] = useState(profile.bio)
-  const [preferredTrades, setPreferredTrades] = useState(profile.preferredTrades)
+  const [preferredTrades, setPreferredTrades] = useState(
+    profile.preferredTrades,
+  )
   const [savedMessage, setSavedMessage] = useState('')
 
   useEffect(() => {
@@ -63,7 +65,10 @@ export default function DashboardProfilePage() {
             <Grid templateColumns={{ base: '1fr', md: '1fr 1fr' }} gap={4}>
               <Stack gap={2}>
                 <Text fontWeight={700}>Full name</Text>
-                <TextInput value={fullName} onChange={(e) => setFullName(e.target.value)} />
+                <TextInput
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                />
               </Stack>
               <Stack gap={2}>
                 <Text fontWeight={700}>Phone number</Text>
@@ -131,7 +136,10 @@ export default function DashboardProfilePage() {
             <Heading size="md">Account summary</Heading>
             <HStack justify="space-between">
               <Text color="muted">Mode</Text>
-              <Badge bg={workerEnabled ? 'primary.50' : 'surfaceContainerHigh'} color={workerEnabled ? 'primary.700' : 'fg'}>
+              <Badge
+                bg={workerEnabled ? 'primary.50' : 'surfaceContainerHigh'}
+                color={workerEnabled ? 'primary.700' : 'fg'}
+              >
                 {workerEnabled ? 'Worker unlocked' : 'Customer only'}
               </Badge>
             </HStack>
@@ -141,8 +149,8 @@ export default function DashboardProfilePage() {
             </HStack>
             <Text fontSize="sm" color="muted">
               Your saved profile details feed the dashboard overview and worker
-              registration flow, making the FE demo feel consistent even when the
-              backend profile schema is still minimal.
+              registration flow, making the FE demo feel consistent even when
+              the backend profile schema is still minimal.
             </Text>
           </Stack>
         </GlassCard>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { Grid, HStack, Stack, Textarea } from '@chakra-ui/react'
+import { useEffect, useState } from 'react'
+
+import {
+  DASHBOARD_TRADE_OPTIONS,
+  type DashboardTrade,
+} from '@/features/dashboard/dashboardDemo'
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import { Badge, Button, GlassCard, Heading, Text, TextInput } from '@ui'
+
+export default function DashboardProfilePage() {
+  const { profile, saveProfile, workerEnabled } = useDashboardData()
+
+  const [fullName, setFullName] = useState(profile.fullName)
+  const [phoneNumber, setPhoneNumber] = useState(profile.phoneNumber)
+  const [location, setLocation] = useState(profile.location)
+  const [bio, setBio] = useState(profile.bio)
+  const [preferredTrades, setPreferredTrades] = useState(profile.preferredTrades)
+  const [savedMessage, setSavedMessage] = useState('')
+
+  useEffect(() => {
+    setFullName(profile.fullName)
+    setPhoneNumber(profile.phoneNumber)
+    setLocation(profile.location)
+    setBio(profile.bio)
+    setPreferredTrades(profile.preferredTrades)
+  }, [profile])
+
+  function toggleTrade(trade: DashboardTrade) {
+    setPreferredTrades((current) =>
+      current.includes(trade)
+        ? current.filter((item) => item !== trade)
+        : [...current, trade],
+    )
+  }
+
+  function handleSave() {
+    saveProfile({
+      fullName,
+      phoneNumber,
+      location,
+      bio,
+      preferredTrades,
+    })
+    setSavedMessage('Profile saved in local dashboard demo storage.')
+  }
+
+  return (
+    <Stack gap={8}>
+      <Stack gap={2}>
+        <Heading size="xl">Profile</Heading>
+        <Text color="muted" maxW="3xl">
+          Update the personal details shown across your dashboard. These values
+          are stored locally for the frontend demo until profile APIs are ready.
+        </Text>
+      </Stack>
+
+      <Grid templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }} gap={6}>
+        <GlassCard p={6}>
+          <Stack gap={5}>
+            <Grid templateColumns={{ base: '1fr', md: '1fr 1fr' }} gap={4}>
+              <Stack gap={2}>
+                <Text fontWeight={700}>Full name</Text>
+                <TextInput value={fullName} onChange={(e) => setFullName(e.target.value)} />
+              </Stack>
+              <Stack gap={2}>
+                <Text fontWeight={700}>Phone number</Text>
+                <TextInput
+                  value={phoneNumber}
+                  onChange={(e) => setPhoneNumber(e.target.value)}
+                  placeholder="+44 7000 000000"
+                />
+              </Stack>
+              <Stack gap={2} gridColumn={{ md: '1 / -1' }}>
+                <Text fontWeight={700}>Location</Text>
+                <TextInput
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  placeholder="City or postcode"
+                />
+              </Stack>
+            </Grid>
+
+            <Stack gap={2}>
+              <Text fontWeight={700}>Bio</Text>
+              <Textarea
+                minH="140px"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                placeholder="Add a short intro that explains how you use HandyBox."
+                bg="surfaceContainerLowest"
+                borderColor="border"
+              />
+            </Stack>
+
+            <Stack gap={3}>
+              <Text fontWeight={700}>Preferred trades</Text>
+              <HStack gap={3} flexWrap="wrap">
+                {DASHBOARD_TRADE_OPTIONS.map((trade) => {
+                  const active = preferredTrades.includes(trade)
+
+                  return (
+                    <Button
+                      key={trade}
+                      size="sm"
+                      variant={active ? 'solid' : 'outline'}
+                      onClick={() => toggleTrade(trade)}
+                    >
+                      {trade}
+                    </Button>
+                  )
+                })}
+              </HStack>
+            </Stack>
+
+            <HStack gap={3} flexWrap="wrap">
+              <Button onClick={() => handleSave()}>Save profile</Button>
+              {savedMessage ? (
+                <Text fontSize="sm" color="primary.700">
+                  {savedMessage}
+                </Text>
+              ) : null}
+            </HStack>
+          </Stack>
+        </GlassCard>
+
+        <GlassCard p={6} bg="surfaceContainerLow">
+          <Stack gap={4}>
+            <Heading size="md">Account summary</Heading>
+            <HStack justify="space-between">
+              <Text color="muted">Mode</Text>
+              <Badge bg={workerEnabled ? 'primary.50' : 'surfaceContainerHigh'} color={workerEnabled ? 'primary.700' : 'fg'}>
+                {workerEnabled ? 'Worker unlocked' : 'Customer only'}
+              </Badge>
+            </HStack>
+            <HStack justify="space-between">
+              <Text color="muted">Preferred trades</Text>
+              <Text fontWeight={700}>{preferredTrades.length}</Text>
+            </HStack>
+            <Text fontSize="sm" color="muted">
+              Your saved profile details feed the dashboard overview and worker
+              registration flow, making the FE demo feel consistent even when the
+              backend profile schema is still minimal.
+            </Text>
+          </Stack>
+        </GlassCard>
+      </Grid>
+    </Stack>
+  )
+}

--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { Grid, HStack, Link, Stack } from '@chakra-ui/react'
+import NextLink from 'next/link'
+
+import { WorkerAccessGate } from '@/app/dashboard/_components/WorkerAccessGate'
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import {
+  formatPounds,
+  formatRelativePosted,
+  getCategoryVisual,
+  isOfferAwarded,
+} from '@/features/dashboard/dashboardHelpers'
+import { Badge, Button, GlassCard, Heading, Text } from '@ui'
+
+function QuoteMetric({
+  label,
+  value,
+  helper,
+}: {
+  label: string
+  value: string
+  helper: string
+}) {
+  return (
+    <GlassCard p={5}>
+      <Stack gap={2}>
+        <Text
+          fontSize="10px"
+          fontWeight={800}
+          letterSpacing="0.08em"
+          color="muted"
+          textTransform="uppercase"
+        >
+          {label}
+        </Text>
+        <Heading size="lg">{value}</Heading>
+        <Text fontSize="sm" color="muted">
+          {helper}
+        </Text>
+      </Stack>
+    </GlassCard>
+  )
+}
+
+export default function DashboardQuotesPage() {
+  const {
+    workerEnabled,
+    tasksLoading,
+    filteredOffers,
+    awardedQuotes,
+    quotesInProgress,
+  } = useDashboardData()
+
+  if (!workerEnabled) {
+    return (
+      <WorkerAccessGate
+        title="Quotes are locked until you create a worker profile"
+        description="Worker features are blocked by default. Register as a worker to unlock quoting, build your service profile, and manage quote activity directly from the dashboard."
+      />
+    )
+  }
+
+  return (
+    <Stack gap={8}>
+      <Stack gap={2}>
+        <HStack justify="space-between" gap={4} flexWrap="wrap">
+          <Stack gap={1} maxW="3xl">
+            <Heading size="xl">Worker Quotes</Heading>
+            <Text color="muted">
+              Review sent quotes, track awarded work, and jump back into the
+              relevant task details whenever you need context.
+            </Text>
+          </Stack>
+          <Button as={NextLink} href="/tasks">
+            Browse jobs
+          </Button>
+        </HStack>
+      </Stack>
+
+      <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={4}>
+        <QuoteMetric
+          label="Sent quotes"
+          value={String(filteredOffers.length)}
+          helper="All quotes that match the current dashboard search."
+        />
+        <QuoteMetric
+          label="Awarded"
+          value={String(awardedQuotes.length)}
+          helper="Quotes that look accepted/awarded from the current task data."
+        />
+        <QuoteMetric
+          label="In progress"
+          value={String(quotesInProgress.length)}
+          helper="Open tasks where your quote is still active."
+        />
+      </Grid>
+
+      {tasksLoading ? <Text color="muted">Loading quote activity…</Text> : null}
+
+      {filteredOffers.length === 0 ? (
+        <GlassCard p={6}>
+          <Stack gap={4}>
+            <Heading size="md">No quotes sent yet</Heading>
+            <Text color="muted">
+              Your worker profile is ready. Browse available jobs and send your
+              first quote to populate this workspace.
+            </Text>
+            <Button as={NextLink} href="/tasks" alignSelf="flex-start">
+              Browse open jobs
+            </Button>
+          </Stack>
+        </GlassCard>
+      ) : (
+        <Stack gap={4}>
+          {filteredOffers.map(({ task, offer }) => {
+            const visual = getCategoryVisual(task.category)
+            const awarded = isOfferAwarded(offer.status)
+
+            return (
+              <GlassCard key={offer.id} p={5}>
+                <HStack align="flex-start" gap={4} flexWrap="wrap">
+                  <Stack
+                    w={14}
+                    h={14}
+                    borderRadius="lg"
+                    bg={visual.bg}
+                    align="center"
+                    justify="center"
+                    fontSize="xl"
+                    flexShrink={0}
+                  >
+                    {visual.glyph}
+                  </Stack>
+                  <Stack gap={2} flex="1" minW="240px">
+                    <HStack justify="space-between" gap={3} flexWrap="wrap">
+                      <Heading size="sm">{task.title}</Heading>
+                      <Badge
+                        bg={awarded ? 'secondaryFixed' : 'surfaceContainerHigh'}
+                        color={awarded ? 'onSecondaryFixed' : 'fg'}
+                      >
+                        {awarded ? 'Awarded' : 'Pending'}
+                      </Badge>
+                    </HStack>
+                    <Text fontSize="sm" color="muted">
+                      {task.location ?? 'Location TBC'} ·{' '}
+                      {formatRelativePosted(offer.createdAt)}
+                    </Text>
+                    <Text fontSize="sm">
+                      Quote value: <strong>{formatPounds(offer.pricePence)}</strong>
+                    </Text>
+                    <Text fontSize="sm" color="muted">
+                      {offer.message?.trim() || 'No message included with this quote.'}
+                    </Text>
+                  </Stack>
+                  <Stack gap={3} align={{ base: 'flex-start', md: 'flex-end' }}>
+                    <Button as={NextLink} href={`/task/${task.id}`} size="sm">
+                      View task
+                    </Button>
+                    <Link
+                      as={NextLink}
+                      href="/dashboard/messages"
+                      fontSize="sm"
+                      fontWeight={700}
+                      color="primary.600"
+                      _hover={{ color: 'primary.700' }}
+                    >
+                      Open messages
+                    </Link>
+                  </Stack>
+                </HStack>
+              </GlassCard>
+            )
+          })}
+        </Stack>
+      )}
+    </Stack>
+  )
+}

--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -47,10 +47,13 @@ export default function DashboardQuotesPage() {
   const {
     workerEnabled,
     tasksLoading,
+    tasksBootstrapping,
     filteredOffers,
     awardedQuotes,
     quotesInProgress,
   } = useDashboardData()
+
+  const isLoadingQuotes = tasksLoading || tasksBootstrapping
 
   if (!workerEnabled) {
     return (
@@ -96,9 +99,11 @@ export default function DashboardQuotesPage() {
         />
       </Grid>
 
-      {tasksLoading ? <Text color="muted">Loading quote activity…</Text> : null}
+      {isLoadingQuotes ? (
+        <Text color="muted">Loading quote activity…</Text>
+      ) : null}
 
-      {filteredOffers.length === 0 ? (
+      {!isLoadingQuotes && filteredOffers.length === 0 ? (
         <GlassCard p={6}>
           <Stack gap={4}>
             <Heading size="md">No quotes sent yet</Heading>
@@ -111,7 +116,7 @@ export default function DashboardQuotesPage() {
             </Button>
           </Stack>
         </GlassCard>
-      ) : (
+      ) : !isLoadingQuotes ? (
         <Stack gap={4}>
           {filteredOffers.map(({ task, offer }) => {
             const visual = getCategoryVisual(task.category)
@@ -147,10 +152,12 @@ export default function DashboardQuotesPage() {
                       {formatRelativePosted(offer.createdAt)}
                     </Text>
                     <Text fontSize="sm">
-                      Quote value: <strong>{formatPounds(offer.pricePence)}</strong>
+                      Quote value:{' '}
+                      <strong>{formatPounds(offer.pricePence)}</strong>
                     </Text>
                     <Text fontSize="sm" color="muted">
-                      {offer.message?.trim() || 'No message included with this quote.'}
+                      {offer.message?.trim() ||
+                        'No message included with this quote.'}
                     </Text>
                   </Stack>
                   <Stack gap={3} align={{ base: 'flex-start', md: 'flex-end' }}>
@@ -173,7 +180,7 @@ export default function DashboardQuotesPage() {
             )
           })}
         </Stack>
-      )}
+      ) : null}
     </Stack>
   )
 }

--- a/src/app/dashboard/worker/register/page.tsx
+++ b/src/app/dashboard/worker/register/page.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import { Box, Grid, HStack, Input as ChakraInput, Stack } from '@chakra-ui/react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+import {
+  DASHBOARD_TRADE_OPTIONS,
+  type DashboardTrade,
+} from '@/features/dashboard/dashboardDemo'
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
+import { formatDate, formatPounds } from '@/features/dashboard/dashboardHelpers'
+import { Badge, Button, GlassCard, Heading, Text, TextInput } from '@ui'
+
+export default function WorkerRegistrationPage() {
+  const router = useRouter()
+  const { profile, workerProfile, registerWorker, saveProfile, workerEnabled } =
+    useDashboardData()
+
+  const [fullName, setFullName] = useState(profile.fullName)
+  const [phoneNumber, setPhoneNumber] = useState(profile.phoneNumber)
+  const [location, setLocation] = useState(profile.location)
+  const [businessName, setBusinessName] = useState(workerProfile.businessName)
+  const [tagline, setTagline] = useState(workerProfile.tagline)
+  const [serviceArea, setServiceArea] = useState(workerProfile.serviceArea)
+  const [yearsExperience, setYearsExperience] = useState(
+    workerProfile.yearsExperience,
+  )
+  const [hourlyRate, setHourlyRate] = useState(
+    String(workerProfile.hourlyRatePence / 100),
+  )
+  const [skills, setSkills] = useState<DashboardTrade[]>(workerProfile.skills)
+  const [verificationFileName, setVerificationFileName] = useState(
+    workerProfile.verificationDocumentName,
+  )
+
+  useEffect(() => {
+    setFullName(profile.fullName)
+    setPhoneNumber(profile.phoneNumber)
+    setLocation(profile.location)
+    setBusinessName(workerProfile.businessName)
+    setTagline(workerProfile.tagline)
+    setServiceArea(workerProfile.serviceArea)
+    setYearsExperience(workerProfile.yearsExperience)
+    setHourlyRate(String(workerProfile.hourlyRatePence / 100))
+    setSkills(workerProfile.skills)
+    setVerificationFileName(workerProfile.verificationDocumentName)
+  }, [profile, workerProfile])
+
+  function toggleSkill(skill: DashboardTrade) {
+    setSkills((current) =>
+      current.includes(skill)
+        ? current.filter((item) => item !== skill)
+        : [...current, skill],
+    )
+  }
+
+  function handleSubmit() {
+    saveProfile({
+      ...profile,
+      fullName,
+      phoneNumber,
+      location,
+    })
+
+    registerWorker({
+      ...workerProfile,
+      isActive: true,
+      businessName,
+      tagline,
+      serviceArea,
+      yearsExperience,
+      hourlyRatePence: Math.max(0, Math.round(Number(hourlyRate || '0') * 100)),
+      skills,
+      verificationDocumentName: verificationFileName,
+      joinedAt: workerProfile.joinedAt ?? new Date().toISOString(),
+    })
+
+    router.push('/dashboard/quotes')
+  }
+
+  return (
+    <Stack gap={8}>
+      <Stack gap={2}>
+        <HStack gap={3} flexWrap="wrap">
+          <Heading size="xl">
+            {workerEnabled ? 'Manage worker profile' : 'Become a worker'}
+          </Heading>
+          {workerEnabled ? (
+            <Badge bg="primary.50" color="primary.700">
+              Active since{' '}
+              {workerProfile.joinedAt ? formatDate(workerProfile.joinedAt) : 'today'}
+            </Badge>
+          ) : null}
+        </HStack>
+        <Text color="muted" maxW="3xl">
+          Complete your worker onboarding to unlock quote submission, earnings
+          tracking, and the worker-side job dashboard. This page uses local demo
+          persistence until the backend worker profile APIs are expanded.
+        </Text>
+      </Stack>
+
+      <Grid templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }} gap={6} alignItems="start">
+        <Stack gap={5}>
+          <GlassCard p={{ base: 5, md: 6 }}>
+            <Stack gap={4}>
+              <HStack gap={3}>
+                <Badge>1</Badge>
+                <Heading size="md">Basic Information</Heading>
+              </HStack>
+              <Grid templateColumns={{ base: '1fr', md: '1fr 1fr' }} gap={4}>
+                <Stack gap={2}>
+                  <Text fontWeight={700}>Full name</Text>
+                  <TextInput value={fullName} onChange={(e) => setFullName(e.target.value)} />
+                </Stack>
+                <Stack gap={2}>
+                  <Text fontWeight={700}>Phone number</Text>
+                  <TextInput
+                    value={phoneNumber}
+                    onChange={(e) => setPhoneNumber(e.target.value)}
+                    placeholder="+44 7000 000000"
+                  />
+                </Stack>
+                <Stack gap={2}>
+                  <Text fontWeight={700}>Business name</Text>
+                  <TextInput
+                    value={businessName}
+                    onChange={(e) => setBusinessName(e.target.value)}
+                    placeholder="Master Craftsman Ltd"
+                  />
+                </Stack>
+                <Stack gap={2}>
+                  <Text fontWeight={700}>Service area</Text>
+                  <TextInput
+                    value={serviceArea}
+                    onChange={(e) => setServiceArea(e.target.value)}
+                    placeholder="City or postcode"
+                  />
+                </Stack>
+                <Stack gap={2} gridColumn={{ md: '1 / -1' }}>
+                  <Text fontWeight={700}>Tagline</Text>
+                  <TextInput
+                    value={tagline}
+                    onChange={(e) => setTagline(e.target.value)}
+                    placeholder="Trusted repairs, clean finishes, reliable communication."
+                  />
+                </Stack>
+              </Grid>
+            </Stack>
+          </GlassCard>
+
+          <GlassCard p={{ base: 5, md: 6 }}>
+            <Stack gap={4}>
+              <HStack gap={3}>
+                <Badge>2</Badge>
+                <Heading size="md">Select Your Skills</Heading>
+              </HStack>
+              <Text color="muted" fontSize="sm">
+                Choose the categories where you have verified experience.
+              </Text>
+              <HStack gap={3} flexWrap="wrap">
+                {DASHBOARD_TRADE_OPTIONS.map((skill) => {
+                  const active = skills.includes(skill)
+
+                  return (
+                    <Button
+                      key={skill}
+                      variant={active ? 'solid' : 'outline'}
+                      size="sm"
+                      onClick={() => toggleSkill(skill)}
+                    >
+                      {skill}
+                    </Button>
+                  )
+                })}
+              </HStack>
+              <Grid templateColumns={{ base: '1fr', md: '1fr 1fr' }} gap={4}>
+                <Stack gap={2}>
+                  <Text fontWeight={700}>Years of experience</Text>
+                  <TextInput
+                    value={yearsExperience}
+                    onChange={(e) => setYearsExperience(e.target.value)}
+                    placeholder="3"
+                  />
+                </Stack>
+                <Stack gap={2}>
+                  <Text fontWeight={700}>Target hourly rate</Text>
+                  <TextInput
+                    value={hourlyRate}
+                    onChange={(e) => setHourlyRate(e.target.value)}
+                    placeholder="45"
+                  />
+                </Stack>
+              </Grid>
+            </Stack>
+          </GlassCard>
+
+          <GlassCard p={{ base: 5, md: 6 }}>
+            <Stack gap={4}>
+              <HStack gap={3}>
+                <Badge>3</Badge>
+                <Heading size="md">Identity Verification</Heading>
+              </HStack>
+              <Box
+                borderRadius="xl"
+                borderWidth="1px"
+                borderStyle="dashed"
+                borderColor="primary.200"
+                p={6}
+                bg="surfaceContainerLow"
+              >
+                <Stack gap={3} align="center" textAlign="center">
+                  <Text fontSize="4xl" aria-hidden>
+                    ☁️
+                  </Text>
+                  <Heading size="sm">Upload Government ID</Heading>
+                  <Text fontSize="sm" color="muted" maxW="md">
+                    We only store the filename in this demo, but the flow mirrors
+                    the production worker verification step.
+                  </Text>
+                  <ChakraInput
+                    type="file"
+                    maxW="sm"
+                    bg="surfaceContainerLowest"
+                    borderColor="border"
+                    onChange={(e) =>
+                      setVerificationFileName(e.target.files?.[0]?.name ?? '')
+                    }
+                  />
+                  {verificationFileName ? (
+                    <Text fontSize="sm" color="primary.700" fontWeight={700}>
+                      Selected: {verificationFileName}
+                    </Text>
+                  ) : null}
+                </Stack>
+              </Box>
+            </Stack>
+          </GlassCard>
+        </Stack>
+
+        <Stack gap={4} position={{ xl: 'sticky' }} top={{ xl: 4 }}>
+          <GlassCard
+            p={6}
+            bg="linear-gradient(160deg, #1a56db 0%, #244bc5 70%, #1236a8 100%)"
+            color="white"
+          >
+            <Stack gap={4}>
+              <Heading size="md" color="white">
+                Why join HandyBox?
+              </Heading>
+              <Stack gap={3}>
+                <Text color="whiteAlpha.900">
+                  Verified worker badge for trust and faster shortlist ranking.
+                </Text>
+                <Text color="whiteAlpha.900">
+                  Earnings workspace with forecasted payouts and quote tracking.
+                </Text>
+                <Text color="whiteAlpha.900">
+                  Service profile that unlocks quote sending across the platform.
+                </Text>
+              </Stack>
+            </Stack>
+          </GlassCard>
+
+          <GlassCard p={6} bg="surfaceContainerLow">
+            <Stack gap={4}>
+              <Heading size="sm">Final step</Heading>
+              <Text fontSize="sm" color="muted">
+                By continuing, you save the worker profile locally and unlock the
+                dashboard quote + earnings sections immediately.
+              </Text>
+              <Stack gap={2}>
+                <HStack justify="space-between">
+                  <Text color="muted" fontSize="sm">
+                    Skills selected
+                  </Text>
+                  <Text fontWeight={700}>{skills.length}</Text>
+                </HStack>
+                <HStack justify="space-between">
+                  <Text color="muted" fontSize="sm">
+                    Rate target
+                  </Text>
+                  <Text fontWeight={700}>
+                    {formatPounds(
+                      Math.max(0, Math.round(Number(hourlyRate || '0') * 100)),
+                    )}
+                    /hr
+                  </Text>
+                </HStack>
+                <HStack justify="space-between">
+                  <Text color="muted" fontSize="sm">
+                    Verification
+                  </Text>
+                  <Text fontWeight={700}>
+                    {verificationFileName ? 'Attached' : 'Pending'}
+                  </Text>
+                </HStack>
+              </Stack>
+              <Button onClick={() => handleSubmit()}>
+                {workerEnabled ? 'Update worker profile' : 'Join HandyBox'}
+              </Button>
+            </Stack>
+          </GlassCard>
+        </Stack>
+      </Grid>
+    </Stack>
+  )
+}

--- a/src/app/dashboard/worker/register/page.tsx
+++ b/src/app/dashboard/worker/register/page.tsx
@@ -1,14 +1,20 @@
 'use client'
 
-import { Box, Grid, HStack, Input as ChakraInput, Stack } from '@chakra-ui/react'
+import {
+  Box,
+  Input as ChakraInput,
+  Grid,
+  HStack,
+  Stack,
+} from '@chakra-ui/react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
+import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
 import {
   DASHBOARD_TRADE_OPTIONS,
   type DashboardTrade,
 } from '@/features/dashboard/dashboardDemo'
-import { useDashboardData } from '@/features/dashboard/DashboardDataContext'
 import { formatDate, formatPounds } from '@/features/dashboard/dashboardHelpers'
 import { Badge, Button, GlassCard, Heading, Text, TextInput } from '@ui'
 
@@ -89,7 +95,9 @@ export default function WorkerRegistrationPage() {
           {workerEnabled ? (
             <Badge bg="primary.50" color="primary.700">
               Active since{' '}
-              {workerProfile.joinedAt ? formatDate(workerProfile.joinedAt) : 'today'}
+              {workerProfile.joinedAt
+                ? formatDate(workerProfile.joinedAt)
+                : 'today'}
             </Badge>
           ) : null}
         </HStack>
@@ -100,7 +108,11 @@ export default function WorkerRegistrationPage() {
         </Text>
       </Stack>
 
-      <Grid templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }} gap={6} alignItems="start">
+      <Grid
+        templateColumns={{ base: '1fr', xl: '1.2fr 0.8fr' }}
+        gap={6}
+        alignItems="start"
+      >
         <Stack gap={5}>
           <GlassCard p={{ base: 5, md: 6 }}>
             <Stack gap={4}>
@@ -111,7 +123,10 @@ export default function WorkerRegistrationPage() {
               <Grid templateColumns={{ base: '1fr', md: '1fr 1fr' }} gap={4}>
                 <Stack gap={2}>
                   <Text fontWeight={700}>Full name</Text>
-                  <TextInput value={fullName} onChange={(e) => setFullName(e.target.value)} />
+                  <TextInput
+                    value={fullName}
+                    onChange={(e) => setFullName(e.target.value)}
+                  />
                 </Stack>
                 <Stack gap={2}>
                   <Text fontWeight={700}>Phone number</Text>
@@ -215,8 +230,8 @@ export default function WorkerRegistrationPage() {
                   </Text>
                   <Heading size="sm">Upload Government ID</Heading>
                   <Text fontSize="sm" color="muted" maxW="md">
-                    We only store the filename in this demo, but the flow mirrors
-                    the production worker verification step.
+                    We only store the filename in this demo, but the flow
+                    mirrors the production worker verification step.
                   </Text>
                   <ChakraInput
                     type="file"
@@ -256,7 +271,8 @@ export default function WorkerRegistrationPage() {
                   Earnings workspace with forecasted payouts and quote tracking.
                 </Text>
                 <Text color="whiteAlpha.900">
-                  Service profile that unlocks quote sending across the platform.
+                  Service profile that unlocks quote sending across the
+                  platform.
                 </Text>
               </Stack>
             </Stack>
@@ -266,8 +282,8 @@ export default function WorkerRegistrationPage() {
             <Stack gap={4}>
               <Heading size="sm">Final step</Heading>
               <Text fontSize="sm" color="muted">
-                By continuing, you save the worker profile locally and unlock the
-                dashboard quote + earnings sections immediately.
+                By continuing, you save the worker profile locally and unlock
+                the dashboard quote + earnings sections immediately.
               </Text>
               <Stack gap={2}>
                 <HStack justify="space-between">

--- a/src/app/task/[slug]/page.tsx
+++ b/src/app/task/[slug]/page.tsx
@@ -581,6 +581,7 @@ export default function TaskDetailPage() {
                                 fill="none"
                                 aria-hidden
                               >
+                                <title>Offers stage</title>
                                 <path
                                   d="M7 18.5 3 21v-3.5A4 4 0 0 1 5 9a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4 4 4 0 0 1-4 4H9l-2 1.5Z"
                                   stroke="currentColor"
@@ -628,7 +629,11 @@ export default function TaskDetailPage() {
                               </Stack>
                             </GlassCard>
                           ) : me && !canAccessWorkerTools ? (
-                            <GlassCard p={6} bg="primary.50" borderColor="primary.100">
+                            <GlassCard
+                              p={6}
+                              bg="primary.50"
+                              borderColor="primary.100"
+                            >
                               <Stack gap={4}>
                                 <Heading size="md">
                                   Become a worker to send a quote

--- a/src/app/task/[slug]/page.tsx
+++ b/src/app/task/[slug]/page.tsx
@@ -5,8 +5,9 @@ import { Box, Grid, HStack, Link, Stack, VStack } from '@chakra-ui/react'
 import type { AddOfferMutation, MeQuery, TaskQuery } from '@codegen/schema'
 import NextLink from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
+import { readDashboardDemoState } from '@/features/dashboard/dashboardDemo'
 import { ME_QUERY } from '@/graphql/auth'
 import { ACCEPT_OFFER_MUTATION, ADD_OFFER, TASK_QUERY } from '@/graphql/jobs'
 import { getAuthToken } from '@/utils/auth'
@@ -122,6 +123,7 @@ export default function TaskDetailPage() {
   const [offerSuccess, setOfferSuccess] = useState<string | null>(null)
   const [acceptError, setAcceptError] = useState<string | null>(null)
   const [acceptingOfferId, setAcceptingOfferId] = useState<string | null>(null)
+  const [workerProfileEnabled, setWorkerProfileEnabled] = useState(false)
 
   const hasToken = typeof window !== 'undefined' && Boolean(getAuthToken())
 
@@ -151,6 +153,16 @@ export default function TaskDetailPage() {
     return task.offers.find((o) => o.workerUserId === me.id) ?? null
   }, [me, task])
 
+  useEffect(() => {
+    if (!me) {
+      setWorkerProfileEnabled(false)
+      return
+    }
+
+    const state = readDashboardDemoState(me.id, me.email)
+    setWorkerProfileEnabled(Boolean(state.worker.isActive))
+  }, [me])
+
   const sortedOffers = useMemo(() => {
     if (!task) return []
     return [...task.offers].sort((a, b) => a.pricePence - b.pricePence)
@@ -173,6 +185,12 @@ export default function TaskDetailPage() {
     if (!getAuthToken()) {
       setOfferError('Please log in before submitting an offer.')
       router.push(`/login?next=${encodeURIComponent(`/task/${task.id}#offer`)}`)
+      return
+    }
+
+    if (!workerProfileEnabled && !myOffer) {
+      setOfferError('Create a worker profile before submitting quotes.')
+      router.push('/dashboard/worker/register')
       return
     }
 
@@ -221,6 +239,7 @@ export default function TaskDetailPage() {
     isOwner &&
     task &&
     ['OPEN', 'POSTED', 'PUBLISHED'].includes(task.status.toUpperCase())
+  const canAccessWorkerTools = Boolean(workerProfileEnabled || myOffer)
 
   if (!taskId) {
     return (
@@ -606,6 +625,27 @@ export default function TaskDetailPage() {
                                 >
                                   Status: {normaliseStatus(myOffer.status)}
                                 </Badge>
+                              </Stack>
+                            </GlassCard>
+                          ) : me && !canAccessWorkerTools ? (
+                            <GlassCard p={6} bg="primary.50" borderColor="primary.100">
+                              <Stack gap={4}>
+                                <Heading size="md">
+                                  Become a worker to send a quote
+                                </Heading>
+                                <Text color="muted">
+                                  Worker features are blocked by default. Create
+                                  your worker profile to unlock quote
+                                  submission, earnings, and worker-side job
+                                  tools.
+                                </Text>
+                                <Button
+                                  as={NextLink}
+                                  href="/dashboard/worker/register"
+                                  alignSelf="flex-start"
+                                >
+                                  Create worker profile
+                                </Button>
                               </Stack>
                             </GlassCard>
                           ) : (

--- a/src/features/dashboard/DashboardDataContext.tsx
+++ b/src/features/dashboard/DashboardDataContext.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import type { MeQuery } from '@codegen/schema'
 import { useQuery } from '@apollo/client/react'
+import type { MeQuery } from '@codegen/schema'
 import {
   createContext,
   useCallback,
@@ -28,13 +28,13 @@ import {
   writeDashboardDemoState,
 } from './dashboardDemo'
 import {
+  type MyOfferItem,
+  type TaskItem,
   formatPounds,
   isOfferAwarded,
   isTaskCompleted,
   matchesSearch,
   timeFromUnknown,
-  type MyOfferItem,
-  type TaskItem,
 } from './dashboardHelpers'
 
 type LiveHistoryItem =
@@ -62,6 +62,7 @@ type DashboardDataContextValue = {
   meLoading: boolean
   meErrorMessage: string | null
   tasksLoading: boolean
+  tasksBootstrapping: boolean
   tasksErrorMessage: string | null
   refetchDashboardData: () => void
   search: string
@@ -92,13 +93,17 @@ type DashboardDataContextValue = {
   markAllMessagesRead: () => void
 }
 
-const DashboardDataContext = createContext<DashboardDataContextValue | null>(null)
+const DashboardDataContext = createContext<DashboardDataContextValue | null>(
+  null,
+)
 
 type DashboardDataProviderProps = {
   children: React.ReactNode
 }
 
 function toHistoryEntry(item: LiveHistoryItem): DashboardHistoryEntry {
+  const completedAtMs = timeFromUnknown(item.completedAt)
+
   return {
     id: item.id,
     title: item.title,
@@ -106,7 +111,7 @@ function toHistoryEntry(item: LiveHistoryItem): DashboardHistoryEntry {
     completedAt:
       typeof item.completedAt === 'string'
         ? item.completedAt
-        : new Date(item.completedAt ?? Date.now()).toISOString(),
+        : new Date(completedAtMs || Date.now()).toISOString(),
     valuePence: item.valuePence,
     summary: item.summary,
     role: item.role,
@@ -160,6 +165,7 @@ export function DashboardDataProvider({
   )
 
   const tasks = tasksData?.tasks.items ?? []
+  const tasksBootstrapping = Boolean(me && !tasksData && !tasksError)
   const meErrorMessage = meError
     ? getFriendlyErrorMessage(meError, 'Could not load account details.')
     : null
@@ -291,7 +297,10 @@ export function DashboardDataProvider({
 
   const totalEarningsPence = useMemo(
     () =>
-      awardedQuotes.reduce((sum, { offer }) => sum + (offer.pricePence ?? 0), 0),
+      awardedQuotes.reduce(
+        (sum, { offer }) => sum + (offer.pricePence ?? 0),
+        0,
+      ),
     [awardedQuotes],
   )
 
@@ -302,14 +311,19 @@ export function DashboardDataProvider({
 
   const userInitial = displayName.charAt(0)?.toUpperCase() || '?'
 
-  const workerEnabled = Boolean(demoState?.worker.isActive || myOffers.length > 0)
+  const workerEnabled = Boolean(
+    demoState?.worker.isActive || myOffers.length > 0,
+  )
 
   const serviceHistory = useMemo(() => {
     const liveEntries = completedHistoryItems.map(toHistoryEntry)
     const demoEntries = demoState?.history ?? []
 
     const combined = [...liveEntries, ...demoEntries]
-      .sort((a, b) => timeFromUnknown(b.completedAt) - timeFromUnknown(a.completedAt))
+      .sort(
+        (a, b) =>
+          timeFromUnknown(b.completedAt) - timeFromUnknown(a.completedAt),
+      )
       .slice(0, 8)
 
     return combined
@@ -401,32 +415,31 @@ export function DashboardDataProvider({
       meLoading,
       meErrorMessage,
       tasksLoading,
+      tasksBootstrapping,
       tasksErrorMessage,
       refetchDashboardData,
       search,
       setSearch,
       displayName,
       userInitial,
-      profile:
-        demoState?.profile ?? {
-          fullName: displayName,
-          bio: '',
-          phoneNumber: '',
-          location: '',
-          preferredTrades: [],
-        },
-      workerProfile:
-        demoState?.worker ?? {
-          isActive: false,
-          businessName: '',
-          tagline: '',
-          serviceArea: '',
-          yearsExperience: '3',
-          hourlyRatePence: 4500,
-          skills: [],
-          verificationDocumentName: '',
-          joinedAt: null,
-        },
+      profile: demoState?.profile ?? {
+        fullName: displayName,
+        bio: '',
+        phoneNumber: '',
+        location: '',
+        preferredTrades: [],
+      },
+      workerProfile: demoState?.worker ?? {
+        isActive: false,
+        businessName: '',
+        tagline: '',
+        serviceArea: '',
+        yearsExperience: '3',
+        hourlyRatePence: 4500,
+        skills: [],
+        verificationDocumentName: '',
+        joinedAt: null,
+      },
       workerEnabled,
       messages: demoState?.messages ?? [],
       serviceHistory,
@@ -475,6 +488,7 @@ export function DashboardDataProvider({
       tasks,
       tasksErrorMessage,
       tasksLoading,
+      tasksBootstrapping,
       totalEarningsPence,
       totalSpendPence,
       updateProfile,
@@ -493,7 +507,9 @@ export function DashboardDataProvider({
 export function useDashboardData() {
   const context = useContext(DashboardDataContext)
   if (!context) {
-    throw new Error('useDashboardData must be used inside DashboardDataProvider.')
+    throw new Error(
+      'useDashboardData must be used inside DashboardDataProvider.',
+    )
   }
 
   return context

--- a/src/features/dashboard/DashboardDataContext.tsx
+++ b/src/features/dashboard/DashboardDataContext.tsx
@@ -1,0 +1,506 @@
+'use client'
+
+import type { MeQuery } from '@codegen/schema'
+import { useQuery } from '@apollo/client/react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+import { ME_QUERY } from '@/graphql/auth'
+import { TASKS_QUERY } from '@/graphql/jobs'
+import type { TasksQueryData } from '@/graphql/tasks-query.types'
+import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
+
+import {
+  type DashboardDemoState,
+  type DashboardHistoryEntry,
+  type DashboardMessage,
+  type DashboardProfile,
+  type DashboardTrade,
+  type DashboardWorkerProfile,
+  getDisplayNameFromEmail,
+  readDashboardDemoState,
+  writeDashboardDemoState,
+} from './dashboardDemo'
+import {
+  formatPounds,
+  isOfferAwarded,
+  isTaskCompleted,
+  matchesSearch,
+  timeFromUnknown,
+  type MyOfferItem,
+  type TaskItem,
+} from './dashboardHelpers'
+
+type LiveHistoryItem =
+  | {
+      id: string
+      title: string
+      location: string
+      completedAt: unknown
+      valuePence: number
+      summary: string
+      role: 'customer'
+    }
+  | {
+      id: string
+      title: string
+      location: string
+      completedAt: unknown
+      valuePence: number
+      summary: string
+      role: 'worker'
+    }
+
+type DashboardDataContextValue = {
+  me: MeQuery['me'] | null
+  meLoading: boolean
+  meErrorMessage: string | null
+  tasksLoading: boolean
+  tasksErrorMessage: string | null
+  refetchDashboardData: () => void
+  search: string
+  setSearch: (value: string) => void
+  displayName: string
+  userInitial: string
+  profile: DashboardProfile
+  workerProfile: DashboardWorkerProfile
+  workerEnabled: boolean
+  messages: DashboardMessage[]
+  serviceHistory: DashboardHistoryEntry[]
+  tasks: TaskItem[]
+  myPostedTasks: TaskItem[]
+  activePostedTasks: TaskItem[]
+  myOffers: MyOfferItem[]
+  filteredPostedTasks: TaskItem[]
+  filteredOffers: MyOfferItem[]
+  quotesInProgress: MyOfferItem[]
+  awardedQuotes: MyOfferItem[]
+  completedHistoryItems: LiveHistoryItem[]
+  customerBookings: TaskItem[]
+  totalSpendPence: number
+  totalEarningsPence: number
+  offerCountOnMyTasks: number
+  saveProfile: (profile: DashboardProfile) => void
+  updateProfile: (patch: Partial<DashboardProfile>) => void
+  registerWorker: (input: DashboardWorkerProfile) => void
+  markAllMessagesRead: () => void
+}
+
+const DashboardDataContext = createContext<DashboardDataContextValue | null>(null)
+
+type DashboardDataProviderProps = {
+  children: React.ReactNode
+}
+
+function toHistoryEntry(item: LiveHistoryItem): DashboardHistoryEntry {
+  return {
+    id: item.id,
+    title: item.title,
+    location: item.location,
+    completedAt:
+      typeof item.completedAt === 'string'
+        ? item.completedAt
+        : new Date(item.completedAt ?? Date.now()).toISOString(),
+    valuePence: item.valuePence,
+    summary: item.summary,
+    role: item.role,
+  }
+}
+
+export function DashboardDataProvider({
+  children,
+}: DashboardDataProviderProps) {
+  const [search, setSearch] = useState('')
+  const [demoState, setDemoState] = useState<DashboardDemoState | null>(null)
+
+  const {
+    data: meData,
+    loading: meLoading,
+    error: meError,
+    refetch: refetchMe,
+  } = useQuery<MeQuery>(ME_QUERY, {
+    fetchPolicy: 'network-only',
+  })
+
+  const me = meData?.me ?? null
+
+  const {
+    data: tasksData,
+    loading: tasksLoading,
+    error: tasksError,
+    refetch: refetchTasks,
+  } = useQuery<TasksQueryData>(TASKS_QUERY, {
+    fetchPolicy: 'network-only',
+    skip: !me,
+  })
+
+  useEffect(() => {
+    if (!me) {
+      setDemoState(null)
+      return
+    }
+
+    setDemoState(readDashboardDemoState(me.id, me.email))
+  }, [me?.email, me?.id, me])
+
+  const persistDemoState = useCallback(
+    (nextState: DashboardDemoState) => {
+      setDemoState(nextState)
+      if (me) {
+        writeDashboardDemoState(me.id, nextState)
+      }
+    },
+    [me],
+  )
+
+  const tasks = tasksData?.tasks.items ?? []
+  const meErrorMessage = meError
+    ? getFriendlyErrorMessage(meError, 'Could not load account details.')
+    : null
+  const tasksErrorMessage = tasksError
+    ? getFriendlyErrorMessage(tasksError, 'Could not load tasks.')
+    : null
+
+  const { myPostedTasks, myOffers, offerCountOnMyTasks } = useMemo(() => {
+    if (!me) {
+      return {
+        myPostedTasks: [] as TaskItem[],
+        myOffers: [] as MyOfferItem[],
+        offerCountOnMyTasks: 0,
+      }
+    }
+
+    const posted = tasks
+      .filter((task) => task.createdByUserId === me.id)
+      .sort(
+        (a, b) => timeFromUnknown(b.createdAt) - timeFromUnknown(a.createdAt),
+      )
+
+    const submitted = tasks
+      .flatMap((task) =>
+        task.offers
+          .filter((offer) => offer.workerUserId === me.id)
+          .map((offer) => ({ task, offer })),
+      )
+      .sort(
+        (a, b) =>
+          timeFromUnknown(b.offer.createdAt) -
+          timeFromUnknown(a.offer.createdAt),
+      )
+
+    const offerCount = posted.reduce(
+      (count, task) => count + task.offers.length,
+      0,
+    )
+
+    return {
+      myPostedTasks: posted,
+      myOffers: submitted,
+      offerCountOnMyTasks: offerCount,
+    }
+  }, [tasks, me])
+
+  const activePostedTasks = useMemo(
+    () => myPostedTasks.filter((task) => !isTaskCompleted(task.status)),
+    [myPostedTasks],
+  )
+
+  const filteredPostedTasks = useMemo(
+    () => activePostedTasks.filter((task) => matchesSearch(task, search)),
+    [activePostedTasks, search],
+  )
+
+  const filteredOffers = useMemo(
+    () => myOffers.filter(({ task }) => matchesSearch(task, search)),
+    [myOffers, search],
+  )
+
+  const quotesInProgress = useMemo(
+    () =>
+      myOffers.filter(({ task }) => !isTaskCompleted(task.status)).slice(0, 4),
+    [myOffers],
+  )
+
+  const awardedQuotes = useMemo(
+    () => myOffers.filter(({ offer }) => isOfferAwarded(offer.status)),
+    [myOffers],
+  )
+
+  const completedAsPoster = useMemo(
+    () => myPostedTasks.filter((task) => isTaskCompleted(task.status)),
+    [myPostedTasks],
+  )
+
+  const completedAsWorker = useMemo(
+    () => myOffers.filter(({ task }) => isTaskCompleted(task.status)),
+    [myOffers],
+  )
+
+  const completedHistoryItems = useMemo<LiveHistoryItem[]>(() => {
+    const posterItems: LiveHistoryItem[] = completedAsPoster.map((task) => ({
+      id: `poster-${task.id}`,
+      title: task.title,
+      location: task.location ?? 'Location TBC',
+      completedAt: task.createdAt,
+      valuePence: task.priceOfferPence ?? 0,
+      summary: 'Posted job completed and archived in your customer history.',
+      role: 'customer',
+    }))
+
+    const workerItems: LiveHistoryItem[] = completedAsWorker.map(
+      ({ task, offer }) => ({
+        id: `worker-${offer.id}`,
+        title: task.title,
+        location: task.location ?? 'Location TBC',
+        completedAt: offer.createdAt,
+        valuePence: offer.pricePence,
+        summary: 'Quote progressed to a completed worker engagement.',
+        role: 'worker',
+      }),
+    )
+
+    return [...posterItems, ...workerItems].sort(
+      (a, b) => timeFromUnknown(b.completedAt) - timeFromUnknown(a.completedAt),
+    )
+  }, [completedAsPoster, completedAsWorker])
+
+  const customerBookings = useMemo(
+    () =>
+      activePostedTasks
+        .filter((task) => task.offers.length > 0)
+        .sort(
+          (a, b) => timeFromUnknown(b.createdAt) - timeFromUnknown(a.createdAt),
+        ),
+    [activePostedTasks],
+  )
+
+  const totalSpendPence = useMemo(
+    () =>
+      completedAsPoster.reduce(
+        (sum, task) => sum + (task.priceOfferPence ?? 0),
+        0,
+      ),
+    [completedAsPoster],
+  )
+
+  const totalEarningsPence = useMemo(
+    () =>
+      awardedQuotes.reduce((sum, { offer }) => sum + (offer.pricePence ?? 0), 0),
+    [awardedQuotes],
+  )
+
+  const displayName = useMemo(() => {
+    const profileName = demoState?.profile.fullName?.trim()
+    return profileName || getDisplayNameFromEmail(me?.email)
+  }, [demoState?.profile.fullName, me?.email])
+
+  const userInitial = displayName.charAt(0)?.toUpperCase() || '?'
+
+  const workerEnabled = Boolean(demoState?.worker.isActive || myOffers.length > 0)
+
+  const serviceHistory = useMemo(() => {
+    const liveEntries = completedHistoryItems.map(toHistoryEntry)
+    const demoEntries = demoState?.history ?? []
+
+    const combined = [...liveEntries, ...demoEntries]
+      .sort((a, b) => timeFromUnknown(b.completedAt) - timeFromUnknown(a.completedAt))
+      .slice(0, 8)
+
+    return combined
+  }, [completedHistoryItems, demoState?.history])
+
+  const saveProfile = useCallback(
+    (profile: DashboardProfile) => {
+      if (!demoState) return
+      persistDemoState({
+        ...demoState,
+        profile: {
+          ...profile,
+          preferredTrades:
+            profile.preferredTrades.length > 0
+              ? profile.preferredTrades
+              : demoState.profile.preferredTrades,
+        },
+      })
+    },
+    [demoState, persistDemoState],
+  )
+
+  const updateProfile = useCallback(
+    (patch: Partial<DashboardProfile>) => {
+      if (!demoState) return
+      persistDemoState({
+        ...demoState,
+        profile: {
+          ...demoState.profile,
+          ...patch,
+          preferredTrades: (patch.preferredTrades ??
+            demoState.profile.preferredTrades) as DashboardTrade[],
+        },
+      })
+    },
+    [demoState, persistDemoState],
+  )
+
+  const registerWorker = useCallback(
+    (workerInput: DashboardWorkerProfile) => {
+      if (!demoState) return
+
+      persistDemoState({
+        ...demoState,
+        worker: {
+          ...workerInput,
+          isActive: true,
+          joinedAt: workerInput.joinedAt ?? new Date().toISOString(),
+        },
+        messages: [
+          {
+            id: `worker-welcome-${Date.now()}`,
+            counterpart: 'Worker Success Team',
+            taskTitle: 'Worker profile',
+            preview:
+              'Your worker profile is live. Start sending quotes and track payouts from your dashboard.',
+            updatedAt: new Date().toISOString(),
+            unread: true,
+          },
+          ...demoState.messages,
+        ].slice(0, 6),
+      })
+    },
+    [demoState, persistDemoState],
+  )
+
+  const markAllMessagesRead = useCallback(() => {
+    if (!demoState) return
+
+    persistDemoState({
+      ...demoState,
+      messages: demoState.messages.map((message) => ({
+        ...message,
+        unread: false,
+      })),
+    })
+  }, [demoState, persistDemoState])
+
+  const refetchDashboardData = useCallback(() => {
+    void refetchMe()
+    if (me) {
+      void refetchTasks()
+    }
+  }, [me, refetchMe, refetchTasks])
+
+  const value = useMemo<DashboardDataContextValue>(
+    () => ({
+      me,
+      meLoading,
+      meErrorMessage,
+      tasksLoading,
+      tasksErrorMessage,
+      refetchDashboardData,
+      search,
+      setSearch,
+      displayName,
+      userInitial,
+      profile:
+        demoState?.profile ?? {
+          fullName: displayName,
+          bio: '',
+          phoneNumber: '',
+          location: '',
+          preferredTrades: [],
+        },
+      workerProfile:
+        demoState?.worker ?? {
+          isActive: false,
+          businessName: '',
+          tagline: '',
+          serviceArea: '',
+          yearsExperience: '3',
+          hourlyRatePence: 4500,
+          skills: [],
+          verificationDocumentName: '',
+          joinedAt: null,
+        },
+      workerEnabled,
+      messages: demoState?.messages ?? [],
+      serviceHistory,
+      tasks,
+      myPostedTasks,
+      activePostedTasks,
+      myOffers,
+      filteredPostedTasks,
+      filteredOffers,
+      quotesInProgress,
+      awardedQuotes,
+      completedHistoryItems,
+      customerBookings,
+      totalSpendPence,
+      totalEarningsPence,
+      offerCountOnMyTasks,
+      saveProfile,
+      updateProfile,
+      registerWorker,
+      markAllMessagesRead,
+    }),
+    [
+      activePostedTasks,
+      awardedQuotes,
+      completedHistoryItems,
+      customerBookings,
+      demoState?.messages,
+      demoState?.profile,
+      demoState?.worker,
+      displayName,
+      filteredOffers,
+      filteredPostedTasks,
+      markAllMessagesRead,
+      me,
+      meErrorMessage,
+      meLoading,
+      myOffers,
+      myPostedTasks,
+      offerCountOnMyTasks,
+      quotesInProgress,
+      refetchDashboardData,
+      registerWorker,
+      saveProfile,
+      search,
+      serviceHistory,
+      tasks,
+      tasksErrorMessage,
+      tasksLoading,
+      totalEarningsPence,
+      totalSpendPence,
+      updateProfile,
+      userInitial,
+      workerEnabled,
+    ],
+  )
+
+  return (
+    <DashboardDataContext.Provider value={value}>
+      {children}
+    </DashboardDataContext.Provider>
+  )
+}
+
+export function useDashboardData() {
+  const context = useContext(DashboardDataContext)
+  if (!context) {
+    throw new Error('useDashboardData must be used inside DashboardDataProvider.')
+  }
+
+  return context
+}
+
+export function buildEarningsHeadline(totalEarningsPence: number) {
+  return totalEarningsPence > 0
+    ? formatPounds(totalEarningsPence)
+    : 'Awaiting first payout'
+}

--- a/src/features/dashboard/dashboardDemo.ts
+++ b/src/features/dashboard/dashboardDemo.ts
@@ -1,0 +1,259 @@
+'use client'
+
+export const DASHBOARD_TRADE_OPTIONS = [
+  'Plumbing',
+  'Electrical',
+  'Carpentry',
+  'Painting',
+  'Landscaping',
+  'HVAC',
+] as const
+
+export type DashboardTrade = (typeof DASHBOARD_TRADE_OPTIONS)[number]
+
+export type DashboardProfile = {
+  fullName: string
+  bio: string
+  phoneNumber: string
+  location: string
+  preferredTrades: DashboardTrade[]
+}
+
+export type DashboardWorkerProfile = {
+  isActive: boolean
+  businessName: string
+  tagline: string
+  serviceArea: string
+  yearsExperience: string
+  hourlyRatePence: number
+  skills: DashboardTrade[]
+  verificationDocumentName: string
+  joinedAt: string | null
+}
+
+export type DashboardMessage = {
+  id: string
+  counterpart: string
+  taskTitle: string
+  preview: string
+  updatedAt: string
+  unread: boolean
+}
+
+export type DashboardHistoryEntry = {
+  id: string
+  title: string
+  location: string
+  completedAt: string
+  valuePence: number
+  summary: string
+  role: 'customer' | 'worker'
+}
+
+export type DashboardDemoState = {
+  profile: DashboardProfile
+  worker: DashboardWorkerProfile
+  messages: DashboardMessage[]
+  history: DashboardHistoryEntry[]
+}
+
+const STORAGE_PREFIX = 'handybox.dashboard.v1'
+
+function titleCase(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
+
+export function getDisplayNameFromEmail(email: string | null | undefined) {
+  const localPart = (email ?? '').split('@')[0]?.trim()
+  if (!localPart) return 'HandyBox Member'
+
+  return localPart
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((piece) => titleCase(piece))
+    .join(' ')
+}
+
+function buildDefaultMessages(displayName: string): DashboardMessage[] {
+  return [
+    {
+      id: 'message-checkin',
+      counterpart: 'Project Support',
+      taskTitle: 'Kitchen tap replacement',
+      preview: `Hi ${displayName.split(' ')[0]}, your shortlist is ready and three pros are available this week.`,
+      updatedAt: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
+      unread: true,
+    },
+    {
+      id: 'message-booking',
+      counterpart: 'Scheduling Assistant',
+      taskTitle: 'Garden fence repair',
+      preview:
+        'We can hold your preferred Saturday morning slot once you confirm the quote.',
+      updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+      unread: false,
+    },
+    {
+      id: 'message-profile',
+      counterpart: 'Trust & Safety',
+      taskTitle: 'Worker profile',
+      preview:
+        'Complete your profile and upload ID to unlock quoting and earnings tools.',
+      updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 30).toISOString(),
+      unread: false,
+    },
+  ]
+}
+
+function buildDefaultHistory(): DashboardHistoryEntry[] {
+  return [
+    {
+      id: 'history-bathroom',
+      title: 'Bathroom extractor fan service',
+      location: 'Manchester',
+      completedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 18).toISOString(),
+      valuePence: 18500,
+      summary: 'Completed with parts supplied and safety check recorded.',
+      role: 'customer',
+    },
+    {
+      id: 'history-garden',
+      title: 'Garden gate hinge replacement',
+      location: 'Leeds',
+      completedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 39).toISOString(),
+      valuePence: 9200,
+      summary: 'Same-day repair with photo proof and invoice delivered.',
+      role: 'customer',
+    },
+  ]
+}
+
+export function createDefaultDashboardState(
+  email: string | null | undefined,
+): DashboardDemoState {
+  const displayName = getDisplayNameFromEmail(email)
+
+  return {
+    profile: {
+      fullName: displayName,
+      bio: 'Homeowner focused on clear briefs, fast communication, and reliable scheduling.',
+      phoneNumber: '',
+      location: 'Greater London',
+      preferredTrades: ['Plumbing', 'Electrical'],
+    },
+    worker: {
+      isActive: false,
+      businessName: '',
+      tagline: '',
+      serviceArea: 'Greater London',
+      yearsExperience: '3',
+      hourlyRatePence: 4500,
+      skills: ['Plumbing'],
+      verificationDocumentName: '',
+      joinedAt: null,
+    },
+    messages: buildDefaultMessages(displayName),
+    history: buildDefaultHistory(),
+  }
+}
+
+function normaliseTrades(value: unknown): DashboardTrade[] {
+  if (!Array.isArray(value)) return []
+
+  return value.filter((item): item is DashboardTrade =>
+    DASHBOARD_TRADE_OPTIONS.includes(item as DashboardTrade),
+  )
+}
+
+function mergeDashboardState(
+  raw: unknown,
+  fallback: DashboardDemoState,
+): DashboardDemoState {
+  if (!raw || typeof raw !== 'object') return fallback
+
+  const input = raw as Partial<DashboardDemoState>
+  const profile = input.profile ?? {}
+  const worker = input.worker ?? {}
+
+  return {
+    profile: {
+      ...fallback.profile,
+      ...profile,
+      preferredTrades:
+        normaliseTrades(profile.preferredTrades).length > 0
+          ? normaliseTrades(profile.preferredTrades)
+          : fallback.profile.preferredTrades,
+    },
+    worker: {
+      ...fallback.worker,
+      ...worker,
+      skills:
+        normaliseTrades(worker.skills).length > 0
+          ? normaliseTrades(worker.skills)
+          : fallback.worker.skills,
+      hourlyRatePence:
+        typeof worker.hourlyRatePence === 'number'
+          ? worker.hourlyRatePence
+          : fallback.worker.hourlyRatePence,
+      joinedAt:
+        typeof worker.joinedAt === 'string' || worker.joinedAt === null
+          ? worker.joinedAt
+          : fallback.worker.joinedAt,
+    },
+    messages: Array.isArray(input.messages)
+      ? input.messages.filter(
+          (item): item is DashboardMessage =>
+            Boolean(
+              item &&
+                typeof item === 'object' &&
+                typeof item.id === 'string' &&
+                typeof item.counterpart === 'string' &&
+                typeof item.preview === 'string',
+            ),
+        )
+      : fallback.messages,
+    history: Array.isArray(input.history)
+      ? input.history.filter(
+          (item): item is DashboardHistoryEntry =>
+            Boolean(
+              item &&
+                typeof item === 'object' &&
+                typeof item.id === 'string' &&
+                typeof item.title === 'string' &&
+                typeof item.location === 'string',
+            ),
+        )
+      : fallback.history,
+  }
+}
+
+function getStorageKey(userId: string) {
+  return `${STORAGE_PREFIX}:${userId}`
+}
+
+export function readDashboardDemoState(
+  userId: string,
+  email: string | null | undefined,
+) {
+  const fallback = createDefaultDashboardState(email)
+
+  if (typeof window === 'undefined') return fallback
+
+  const raw = window.localStorage.getItem(getStorageKey(userId))
+  if (!raw) return fallback
+
+  try {
+    return mergeDashboardState(JSON.parse(raw), fallback)
+  } catch {
+    return fallback
+  }
+}
+
+export function writeDashboardDemoState(
+  userId: string,
+  nextState: DashboardDemoState,
+) {
+  if (typeof window === 'undefined') return
+
+  window.localStorage.setItem(getStorageKey(userId), JSON.stringify(nextState))
+}

--- a/src/features/dashboard/dashboardDemo.ts
+++ b/src/features/dashboard/dashboardDemo.ts
@@ -111,7 +111,9 @@ function buildDefaultHistory(): DashboardHistoryEntry[] {
       id: 'history-bathroom',
       title: 'Bathroom extractor fan service',
       location: 'Manchester',
-      completedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 18).toISOString(),
+      completedAt: new Date(
+        Date.now() - 1000 * 60 * 60 * 24 * 18,
+      ).toISOString(),
       valuePence: 18500,
       summary: 'Completed with parts supplied and safety check recorded.',
       role: 'customer',
@@ -120,7 +122,9 @@ function buildDefaultHistory(): DashboardHistoryEntry[] {
       id: 'history-garden',
       title: 'Garden gate hinge replacement',
       location: 'Leeds',
-      completedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 39).toISOString(),
+      completedAt: new Date(
+        Date.now() - 1000 * 60 * 60 * 24 * 39,
+      ).toISOString(),
       valuePence: 9200,
       summary: 'Same-day repair with photo proof and invoice delivered.',
       role: 'customer',
@@ -172,8 +176,8 @@ function mergeDashboardState(
   if (!raw || typeof raw !== 'object') return fallback
 
   const input = raw as Partial<DashboardDemoState>
-  const profile = input.profile ?? {}
-  const worker = input.worker ?? {}
+  const profile = (input.profile ?? {}) as Partial<DashboardProfile>
+  const worker = (input.worker ?? {}) as Partial<DashboardWorkerProfile>
 
   return {
     profile: {
@@ -201,27 +205,25 @@ function mergeDashboardState(
           : fallback.worker.joinedAt,
     },
     messages: Array.isArray(input.messages)
-      ? input.messages.filter(
-          (item): item is DashboardMessage =>
-            Boolean(
-              item &&
-                typeof item === 'object' &&
-                typeof item.id === 'string' &&
-                typeof item.counterpart === 'string' &&
-                typeof item.preview === 'string',
-            ),
+      ? input.messages.filter((item): item is DashboardMessage =>
+          Boolean(
+            item &&
+              typeof item === 'object' &&
+              typeof item.id === 'string' &&
+              typeof item.counterpart === 'string' &&
+              typeof item.preview === 'string',
+          ),
         )
       : fallback.messages,
     history: Array.isArray(input.history)
-      ? input.history.filter(
-          (item): item is DashboardHistoryEntry =>
-            Boolean(
-              item &&
-                typeof item === 'object' &&
-                typeof item.id === 'string' &&
-                typeof item.title === 'string' &&
-                typeof item.location === 'string',
-            ),
+      ? input.history.filter((item): item is DashboardHistoryEntry =>
+          Boolean(
+            item &&
+              typeof item === 'object' &&
+              typeof item.id === 'string' &&
+              typeof item.title === 'string' &&
+              typeof item.location === 'string',
+          ),
         )
       : fallback.history,
   }

--- a/src/features/dashboard/dashboardHelpers.ts
+++ b/src/features/dashboard/dashboardHelpers.ts
@@ -1,0 +1,132 @@
+'use client'
+
+import type { TasksQueryData } from '@/graphql/tasks-query.types'
+
+export type TaskItem = TasksQueryData['tasks']['items'][number]
+export type TaskOfferItem = TaskItem['offers'][number]
+export type MyOfferItem = {
+  task: TaskItem
+  offer: TaskOfferItem
+}
+
+export function formatPounds(pricePence: number) {
+  return `£${(pricePence / 100).toFixed(0)}`
+}
+
+export function timeFromUnknown(value: unknown): number {
+  const d =
+    typeof value === 'string' || typeof value === 'number'
+      ? new Date(value)
+      : value instanceof Date
+        ? value
+        : null
+
+  return d && !Number.isNaN(d.getTime()) ? d.getTime() : 0
+}
+
+export function formatDate(iso: unknown) {
+  const d =
+    typeof iso === 'string' || typeof iso === 'number'
+      ? new Date(iso)
+      : iso instanceof Date
+        ? iso
+        : null
+
+  if (!d || Number.isNaN(d.getTime())) return '—'
+
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(d)
+}
+
+export function formatRelativePosted(iso: unknown): string {
+  const ms = timeFromUnknown(iso)
+  if (!ms) return 'Recently'
+
+  const diff = Date.now() - ms
+  const minutes = Math.floor(diff / 60000)
+
+  if (minutes < 1) return 'Posted just now'
+  if (minutes < 60) return `Posted ${minutes}m ago`
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Posted ${hours}h ago`
+
+  const days = Math.floor(hours / 24)
+  if (days === 1) return 'Posted yesterday'
+  if (days < 7) return `Posted ${days} days ago`
+
+  return `Posted ${formatDate(iso)}`
+}
+
+export function isTaskCompleted(status: string) {
+  return /complete|done|closed|paid|archived|finished|resolved/i.test(
+    status.trim(),
+  )
+}
+
+export function isOfferAwarded(status: string) {
+  return /accept|award|select|win|approved|chosen/i.test(status.trim())
+}
+
+export function matchesSearch(task: TaskItem, q: string) {
+  const search = q.trim().toLowerCase()
+  if (!search) return true
+
+  return (
+    task.title.toLowerCase().includes(search) ||
+    (task.description ?? '').toLowerCase().includes(search) ||
+    (task.location ?? '').toLowerCase().includes(search) ||
+    (task.category ?? '').toLowerCase().includes(search)
+  )
+}
+
+export function getOfferRange(offers: Array<{ pricePence: number }>) {
+  if (offers.length === 0) return null
+
+  const prices = offers.map((offer) => offer.pricePence)
+  const min = Math.min(...prices)
+  const max = Math.max(...prices)
+
+  return min === max
+    ? formatPounds(min)
+    : `${formatPounds(min)}–${formatPounds(max)}`
+}
+
+export function getCategoryVisual(category: string | null | undefined) {
+  const key = (category ?? '').toLowerCase()
+
+  if (key.includes('plumb') || key.includes('water')) {
+    return {
+      glyph: '🏠',
+      bg: 'linear-gradient(135deg, #d9e6ff 0%, #b5ceff 100%)',
+    }
+  }
+
+  if (key.includes('electr')) {
+    return {
+      glyph: '🔌',
+      bg: 'linear-gradient(135deg, #dfe8f7 0%, #8fb4ff 100%)',
+    }
+  }
+
+  if (key.includes('paint') || key.includes('decor')) {
+    return {
+      glyph: '🎨',
+      bg: 'linear-gradient(135deg, #fff4e4 0%, #ffddb8 100%)',
+    }
+  }
+
+  if (key.includes('heat') || key.includes('hvac')) {
+    return {
+      glyph: '🌡️',
+      bg: 'linear-gradient(135deg, #e8fff3 0%, #b2f5d6 100%)',
+    }
+  }
+
+  return {
+    glyph: '🔧',
+    bg: 'linear-gradient(135deg, #eef4ff 0%, #dfe8f7 100%)',
+  }
+}

--- a/src/ui/DashboardShell/DashboardShell.stories.tsx
+++ b/src/ui/DashboardShell/DashboardShell.stories.tsx
@@ -9,11 +9,13 @@ function DashboardShellStory() {
   const [search, setSearch] = useState('')
   return (
     <DashboardShell
-      activeNav="my-jobs"
+      activeNav="jobs"
       searchValue={search}
       onSearchChange={setSearch}
       userLabel="craftsman@example.com"
       userInitial="C"
+      userStatus="Verified worker workspace"
+      workerEnabled
     >
       <Stack gap={4}>
         <Heading size="lg">My Jobs</Heading>

--- a/src/ui/DashboardShell/DashboardShell.tsx
+++ b/src/ui/DashboardShell/DashboardShell.tsx
@@ -1,19 +1,22 @@
 'use client'
 
-import { Box, HStack, Link, Stack } from '@chakra-ui/react'
+import { Box, HStack, Link, Stack, Text as ChakraText } from '@chakra-ui/react'
 import NextLink from 'next/link'
 
+import { Button } from '../Button'
+import { GlassCard } from '../Card/GlassCard'
 import { TextInput } from '../Input'
 import { Heading, Text } from '../Typography'
 
 export type DashboardNavKey =
-  | 'dashboard'
-  | 'my-jobs'
+  | 'overview'
+  | 'jobs'
   | 'quotes'
+  | 'earnings'
+  | 'history'
   | 'messages'
-  | 'payments'
-  | 'settings'
-  | 'support'
+  | 'profile'
+  | 'worker-register'
 
 export type DashboardShellProps = {
   activeNav?: DashboardNavKey
@@ -22,6 +25,11 @@ export type DashboardShellProps = {
   onSearchChange: (value: string) => void
   userLabel: string
   userInitial: string
+  userStatus?: string
+  userMeta?: string
+  workerEnabled?: boolean
+  workerCtaHref?: string
+  headerAction?: React.ReactNode
   children: React.ReactNode
 }
 
@@ -53,14 +61,15 @@ const navPrimary: Array<{
   label: string
   href: string
   icon: React.ReactNode
+  workerOnly?: boolean
 }> = [
   {
-    key: 'dashboard',
-    label: 'Dashboard',
-    href: '/',
+    key: 'overview',
+    label: 'Overview',
+    href: '/dashboard',
     icon: (
       <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
-        <title>Dashboard</title>
+        <title>Overview</title>
         <path
           d="M4 10.5 12 4l8 6.5V20a1 1 0 0 1-1 1h-5v-6H10v6H5a1 1 0 0 1-1-1v-9.5Z"
           stroke="currentColor"
@@ -71,9 +80,9 @@ const navPrimary: Array<{
     ),
   },
   {
-    key: 'my-jobs',
+    key: 'jobs',
     label: 'My Jobs',
-    href: '/dashboard',
+    href: '/dashboard/jobs',
     icon: (
       <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
         <title>My Jobs</title>
@@ -89,7 +98,8 @@ const navPrimary: Array<{
   {
     key: 'quotes',
     label: 'Quotes',
-    href: '/dashboard?view=quotes',
+    href: '/dashboard/quotes',
+    workerOnly: true,
     icon: (
       <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
         <title>Quotes</title>
@@ -103,28 +113,13 @@ const navPrimary: Array<{
     ),
   },
   {
-    key: 'messages',
-    label: 'Messages',
-    href: '/dashboard',
+    key: 'earnings',
+    label: 'Earnings',
+    href: '/dashboard/earnings',
+    workerOnly: true,
     icon: (
       <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
-        <title>Messages</title>
-        <path
-          d="M5 19.5 8.25 17H18a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v12.5Z"
-          stroke="currentColor"
-          strokeWidth="1.75"
-          strokeLinejoin="round"
-        />
-      </svg>
-    ),
-  },
-  {
-    key: 'payments',
-    label: 'Payments',
-    href: '/dashboard',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
-        <title>Payments</title>
+        <title>Earnings</title>
         <rect
           x="3"
           y="5"
@@ -144,6 +139,68 @@ const navPrimary: Array<{
       </svg>
     ),
   },
+  {
+    key: 'history',
+    label: 'History',
+    href: '/dashboard/history',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>History</title>
+        <path
+          d="M12 8v5l3 2"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+        <path
+          d="M4.93 4.93A9.97 9.97 0 0 1 12 2a10 10 0 1 1-7.07 2.93M3 8V3h5"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'messages',
+    label: 'Messages',
+    href: '/dashboard/messages',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Messages</title>
+        <path
+          d="M5 19.5 8.25 17H18a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v12.5Z"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinejoin="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    key: 'profile',
+    label: 'Profile',
+    href: '/dashboard/profile',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
+        <title>Profile</title>
+        <circle
+          cx="12"
+          cy="8"
+          r="3.25"
+          stroke="currentColor"
+          strokeWidth="1.75"
+        />
+        <path
+          d="M5 20a7 7 0 0 1 14 0"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
 ]
 
 const navSecondary: Array<{
@@ -153,51 +210,22 @@ const navSecondary: Array<{
   icon: React.ReactNode
 }> = [
   {
-    key: 'settings',
-    label: 'Settings',
-    href: '/dashboard',
+    key: 'worker-register',
+    label: 'Worker setup',
+    href: '/dashboard/worker/register',
     icon: (
       <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
-        <title>Settings</title>
+        <title>Worker setup</title>
         <path
-          d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
+          d="m12 4 7 4v8l-7 4-7-4V8l7-4Z"
           stroke="currentColor"
           strokeWidth="1.75"
         />
         <path
-          d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1-1.51V13a2 2 0 0 1 4 0v.09A1.65 1.65 0 0 0 8 12.6a1.65 1.65 0 0 0-1.82-.33l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 12 8.6V8a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V15c.26.6.74 1.08 1.34 1.34V17a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1.51-1Z"
-          stroke="currentColor"
-          strokeWidth="1.75"
-          strokeLinejoin="round"
-        />
-      </svg>
-    ),
-  },
-  {
-    key: 'support',
-    label: 'Support',
-    href: '/dashboard',
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" width="100%" height="100%">
-        <title>Support</title>
-        <path
-          d="M9.09 9a3 3 0 1 1 5.83 1c0 2-3 2-3 4"
+          d="M9.5 12h5M12 9.5V14.5"
           stroke="currentColor"
           strokeWidth="1.75"
           strokeLinecap="round"
-        />
-        <path
-          d="M12 17h.01"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-        />
-        <circle
-          cx="12"
-          cy="12"
-          r="9"
-          stroke="currentColor"
-          strokeWidth="1.75"
         />
       </svg>
     ),
@@ -209,11 +237,13 @@ function SidebarNavLink({
   label,
   icon,
   active,
+  locked,
 }: {
   href: string
   label: string
   icon: React.ReactNode
   active: boolean
+  locked?: boolean
 }) {
   return (
     <Link
@@ -228,7 +258,7 @@ function SidebarNavLink({
       borderLeftWidth="3px"
       borderLeftColor={active ? 'primary.500' : 'transparent'}
       bg={active ? 'primary.50' : 'transparent'}
-      color={active ? 'primary.700' : 'muted'}
+      color={active ? 'primary.700' : locked ? 'fg.subtle' : 'muted'}
       fontWeight={active ? 700 : 600}
       fontSize="sm"
       transition="background 0.15s ease, color 0.15s ease"
@@ -239,18 +269,30 @@ function SidebarNavLink({
       }}
     >
       <NavIcon>{icon}</NavIcon>
-      {label}
+      <HStack gap={2} justify="space-between" flex="1">
+        <ChakraText>{label}</ChakraText>
+        {locked ? (
+          <ChakraText fontSize="10px" color="primary.700" fontWeight={800}>
+            LOCKED
+          </ChakraText>
+        ) : null}
+      </HStack>
     </Link>
   )
 }
 
 export function DashboardShell({
-  activeNav = 'my-jobs',
-  searchPlaceholder = 'Search your jobs…',
+  activeNav = 'overview',
+  searchPlaceholder = 'Search jobs, quotes, or records…',
   searchValue,
   onSearchChange,
   userLabel,
   userInitial,
+  userStatus,
+  userMeta,
+  workerEnabled = false,
+  workerCtaHref = '/dashboard/worker/register',
+  headerAction,
   children,
 }: DashboardShellProps) {
   return (
@@ -263,7 +305,7 @@ export function DashboardShell({
       >
         <Box
           as="aside"
-          w={{ base: 'full', md: '260px' }}
+          w={{ base: 'full', md: '280px' }}
           flexShrink={0}
           borderRightWidth={{ base: 0, md: '1px' }}
           borderBottomWidth={{ base: '1px', md: 0 }}
@@ -273,7 +315,7 @@ export function DashboardShell({
           py={{ base: 4, md: 8 }}
         >
           <Stack
-            gap={8}
+            gap={6}
             maxH={{ md: '100vh' }}
             position={{ md: 'sticky' }}
             top={{ md: 0 }}
@@ -313,10 +355,45 @@ export function DashboardShell({
                   color="muted"
                   textTransform="uppercase"
                 >
-                  Master Craftsman Portal
+                  Dashboard workspace
                 </Text>
               </Stack>
             </HStack>
+
+            <GlassCard p={4} bg="surfaceContainerLow">
+              <Stack gap={1}>
+                <HStack gap={3}>
+                  <Box
+                    w={10}
+                    h={10}
+                    borderRadius="full"
+                    bg="primary.500"
+                    color="white"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    fontWeight={800}
+                    fontSize="sm"
+                    flexShrink={0}
+                  >
+                    {userInitial}
+                  </Box>
+                  <Stack gap={0}>
+                    <Heading size="sm">{userLabel}</Heading>
+                    {userStatus ? (
+                      <Text fontSize="xs" color="primary.700" fontWeight={700}>
+                        {userStatus}
+                      </Text>
+                    ) : null}
+                  </Stack>
+                </HStack>
+                {userMeta ? (
+                  <Text fontSize="xs" color="muted">
+                    {userMeta}
+                  </Text>
+                ) : null}
+              </Stack>
+            </GlassCard>
 
             <Stack gap={1} flex="1">
               {navPrimary.map((item) => (
@@ -326,6 +403,7 @@ export function DashboardShell({
                   label={item.label}
                   icon={item.icon}
                   active={item.key === activeNav}
+                  locked={Boolean(item.workerOnly && !workerEnabled)}
                 />
               ))}
             </Stack>
@@ -341,6 +419,51 @@ export function DashboardShell({
                 />
               ))}
             </Stack>
+
+            <GlassCard
+              p={4}
+              bg={
+                workerEnabled
+                  ? 'linear-gradient(160deg, #03225a 0%, #012b73 55%, #00358f 100%)'
+                  : 'primary.50'
+              }
+              color={workerEnabled ? 'white' : 'fg'}
+            >
+              <Stack gap={3}>
+                <Text
+                  fontSize="10px"
+                  fontWeight={800}
+                  letterSpacing="0.08em"
+                  color={workerEnabled ? 'whiteAlpha.800' : 'primary.700'}
+                >
+                  {workerEnabled ? 'WORKER MODE ACTIVE' : 'WORKER FEATURES LOCKED'}
+                </Text>
+                <Heading size="sm" color={workerEnabled ? 'white' : undefined}>
+                  {workerEnabled
+                    ? 'Quotes and earnings are unlocked.'
+                    : 'Become a worker to send quotes.'}
+                </Heading>
+                <Text
+                  fontSize="sm"
+                  color={workerEnabled ? 'whiteAlpha.900' : 'muted'}
+                >
+                  {workerEnabled
+                    ? 'Track active quotes, monitor payout totals, and keep your professional profile ready for new work.'
+                    : 'Create your worker profile to unlock quoting, job intake, and payout tracking in the dashboard.'}
+                </Text>
+                <Button
+                  as={NextLink}
+                  href={workerCtaHref}
+                  size="sm"
+                  variant={workerEnabled ? 'subtle' : 'solid'}
+                  bg={workerEnabled ? 'whiteAlpha.200' : undefined}
+                  color={workerEnabled ? 'white' : undefined}
+                  alignSelf="flex-start"
+                >
+                  {workerEnabled ? 'Manage worker profile' : 'Become a worker'}
+                </Button>
+              </Stack>
+            </GlassCard>
           </Stack>
         </Box>
 
@@ -393,6 +516,7 @@ export function DashboardShell({
                 aria-label="Search jobs"
               />
             </Box>
+            {headerAction ? <Box>{headerAction}</Box> : null}
             <HStack gap={2} ml={{ base: 0, md: 'auto' }}>
               <Box
                 as="button"

--- a/src/ui/DashboardShell/DashboardShell.tsx
+++ b/src/ui/DashboardShell/DashboardShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Box, HStack, Link, Stack, Text as ChakraText } from '@chakra-ui/react'
+import { Box, Text as ChakraText, HStack, Link, Stack } from '@chakra-ui/react'
 import NextLink from 'next/link'
 
 import { Button } from '../Button'
@@ -258,7 +258,7 @@ function SidebarNavLink({
       borderLeftWidth="3px"
       borderLeftColor={active ? 'primary.500' : 'transparent'}
       bg={active ? 'primary.50' : 'transparent'}
-      color={active ? 'primary.700' : locked ? 'fg.subtle' : 'muted'}
+      color={active ? 'primary.700' : locked ? 'muted' : 'muted'}
       fontWeight={active ? 700 : 600}
       fontSize="sm"
       transition="background 0.15s ease, color 0.15s ease"
@@ -436,7 +436,9 @@ export function DashboardShell({
                   letterSpacing="0.08em"
                   color={workerEnabled ? 'whiteAlpha.800' : 'primary.700'}
                 >
-                  {workerEnabled ? 'WORKER MODE ACTIVE' : 'WORKER FEATURES LOCKED'}
+                  {workerEnabled
+                    ? 'WORKER MODE ACTIVE'
+                    : 'WORKER FEATURES LOCKED'}
                 </Text>
                 <Heading size="sm" color={workerEnabled ? 'white' : undefined}>
                   {workerEnabled

--- a/src/ui/Header/Header.tsx
+++ b/src/ui/Header/Header.tsx
@@ -25,9 +25,9 @@ type NavItem = {
 const navItems: readonly NavItem[] = [
   { key: 'home', label: 'Home', href: '/' },
   { key: 'tasks', label: 'Tasks', href: '/tasks' },
-  { key: 'my-jobs', label: 'My Jobs', href: '/dashboard' },
+  { key: 'my-jobs', label: 'My Jobs', href: '/dashboard/jobs' },
   { key: 'post-job', label: 'Post a Job', href: '/tasks/create' },
-  { key: 'profile', label: 'Profile', href: '/dashboard' },
+  { key: 'profile', label: 'Profile', href: '/dashboard/profile' },
 ]
 
 export type HeaderProps = {

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -11,14 +11,7 @@ export { Container } from './Container'
 export { DashboardShell } from './DashboardShell/DashboardShell'
 export { FormField } from './FormField/FormField'
 export { GlassCard } from './Card/GlassCard'
-export {
-  IconCalendar,
-  IconClock,
-  IconDocument,
-  IconMapPin,
-  IconSliders,
-  IconWrench,
-} from './TaskBrowse/TaskBrowseMetaIcons'
+export { IconCalendar, IconClock, IconDocument, IconMapPin, IconSliders, IconWrench } from './TaskBrowse/TaskBrowseMetaIcons'
 export { Input, TextInput } from './Input'
 export { TaskBrowseFilters } from './TaskBrowseFilters/TaskBrowseFilters'
 export { TaskListPagination } from './TaskListPagination/TaskListPagination'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the single dashboard page with routed overview, jobs, quotes, earnings, history, messages, profile, and worker registration sections
- add a shared dashboard data layer that combines live task data with local demo state for profile, history, messages, and worker onboarding
- gate quote submission and worker-only dashboard areas behind worker profile creation while keeping existing task detail flows connected
- fix the follow-up TypeScript/build regressions and smooth initial dashboard loading states so pages do not flash incorrect empty states

## Testing
- [x] `bunx biome check src/app/dashboard src/app/task/[slug]/page.tsx src/ui/DashboardShell src/ui/Header/Header.tsx src/features/dashboard`
- [x] `bun run build`
- [x] manual dashboard walkthrough

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-16](https://linear.app/handybox/issue/FE-16/redactor-the-dashboard)

<div><a href="https://cursor.com/agents/bc-bc230513-eaa4-4476-9779-2f9fd47f9120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc230513-eaa4-4476-9779-2f9fd47f9120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

