### PR TITLE
Sync task GraphQL and UI with BE task schema (BE-11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@emotion/styled": "^11.14.1",
         "embla-carousel-react": "^8.6.0",
         "embla-carousel-wheel-gestures": "^8.1.0",
-        "framer-motion": "^12.31.0",
         "graphql": "^16.12.0",
         "mapbox-gl": "^3.17.0",
         "motion": "^12.38.0",
@@ -9805,7 +9804,7 @@
     },
     "node_modules/ws": {
       "version": "8.19.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/src/app/(customer)/quotes/page.tsx
+++ b/src/app/(customer)/quotes/page.tsx
@@ -8,6 +8,7 @@ import {
   formatPounds,
   getCategoryVisual,
 } from '@/utils/dashboardHelpers'
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 import { Badge, Button, GlassCard, Heading, Text } from '@ui'
 import { useCustomerAccount } from '../context/CustomerAccountContext'
 
@@ -70,7 +71,7 @@ export default function CustomerQuotesPage() {
                   <Stack gap={2} flex="1" minW="200px">
                     <Heading size="sm">{task.title}</Heading>
                     <Text fontSize="sm" color="muted">
-                      {task.location ?? 'Location TBC'}
+                      {taskPublicLocationLabel(task) || 'Location TBC'}
                     </Text>
                     <HStack gap={2} flexWrap="wrap">
                       <Badge bg="primary.50" color="primary.700">

--- a/src/app/(customer)/requests/page.tsx
+++ b/src/app/(customer)/requests/page.tsx
@@ -14,6 +14,7 @@ import {
   isOfferAwarded,
   isTaskCompleted,
 } from '@/utils/dashboardHelpers'
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 import { Badge, Button, GlassCard, Heading, Text } from '@ui'
 import { useCustomerAccount } from '../context'
 
@@ -83,7 +84,8 @@ function TaskCard({ task }: { task: TaskItem }) {
         <Stack gap={1}>
           <Heading size="sm">{task.title}</Heading>
           <Text fontSize="sm" color="muted">
-            {formatDate(task.createdAt)} {'•'} {task.location ?? 'Metro Area'}
+            {formatDate(task.createdAt)} {'•'}{' '}
+            {taskPublicLocationLabel(task) || 'Metro Area'}
           </Text>
         </Stack>
 
@@ -308,7 +310,7 @@ export default function CustomerRequestsPage() {
                       <Heading size="sm">{task.title}</Heading>
                       <Text fontSize="sm" color="muted">
                         {task.offers.length} quotes {'•'}{' '}
-                        {task.location ?? 'Location TBC'}
+                        {taskPublicLocationLabel(task) || 'Location TBC'}
                       </Text>
                       <Link
                         as={NextLink}

--- a/src/app/(task)/components/(mobile)/MobileLayout.tsx
+++ b/src/app/(task)/components/(mobile)/MobileLayout.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+import {
+  formatTaskCategoryLabel,
+  taskPublicLocationLabel,
+} from '@/utils/taskLocationDisplay'
 import { Box, HStack, IconButton, Input } from '@chakra-ui/react'
 import { Button } from '@ui'
 import { SearchThisAreaButton } from '../(web)/SearchThisAreaButton'
@@ -39,7 +43,7 @@ export function MobileLayout() {
       id: task.id,
       title: task.title,
       description: task.description,
-      location: task.location?.trim() || 'Location on request',
+      location: taskPublicLocationLabel(task).trim() || 'Location on request',
       priceLabel: main,
       badgeText: badge.text,
       imageSeed: task.id,
@@ -51,7 +55,11 @@ export function MobileLayout() {
     selectedCategorySet.size > 0 &&
     selectedCategorySet.size < categories.length
   ) {
-    activeFilterTags.push(...[...selectedCategorySet].slice(0, 3))
+    activeFilterTags.push(
+      ...[...selectedCategorySet]
+        .slice(0, 3)
+        .map((c) => formatTaskCategoryLabel(c)),
+    )
   }
   if (urgency !== 'any') {
     activeFilterTags.push(

--- a/src/app/(task)/components/(web)/TaskBrowseFilters.tsx
+++ b/src/app/(task)/components/(web)/TaskBrowseFilters.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatTaskCategoryLabel } from '@/utils/taskLocationDisplay'
 import {
   Box,
   Checkbox,
@@ -9,6 +10,7 @@ import {
   Slider,
   Stack,
 } from '@chakra-ui/react'
+import type { TaskCategory } from '@codegen/schema'
 import { Button, Heading, Text, TextInput } from '@ui'
 
 const FILTER_LABEL = {
@@ -22,9 +24,9 @@ const FILTER_LABEL = {
 export type UrgencyFilter = 'any' | 'emergency' | 'today' | 'week'
 
 export type TaskBrowseFiltersProps = {
-  categories: readonly string[]
-  selectedCategories: Set<string>
-  onToggleCategory: (category: string, checked: boolean) => void
+  categories: readonly TaskCategory[]
+  selectedCategories: Set<TaskCategory>
+  onToggleCategory: (category: TaskCategory, checked: boolean) => void
   searchQuery: string
   onSearchChange: (value: string) => void
   areaLocationInput?: string
@@ -185,7 +187,7 @@ export function TaskBrowseFilters({
                     justifyContent="flex-start"
                     onClick={() => onToggleCategory(cat, !active)}
                   >
-                    {cat}
+                    {formatTaskCategoryLabel(cat)}
                   </Button>
                 )
               })}
@@ -276,7 +278,9 @@ export function TaskBrowseFilters({
                 <Checkbox.HiddenInput />
                 <HStack gap={3} align="center">
                   <Checkbox.Control />
-                  <Checkbox.Label>{cat}</Checkbox.Label>
+                  <Checkbox.Label>
+                    {formatTaskCategoryLabel(cat)}
+                  </Checkbox.Label>
                 </HStack>
               </Checkbox.Root>
             ))}

--- a/src/app/(task)/components/(web)/TaskList.tsx
+++ b/src/app/(task)/components/(web)/TaskList.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { TaskBrowseListItem } from './TaskBrowseListItem'
 
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 import { useTaskBrowseData } from '../../context/TaskBrowseProvider'
 import { formatBudget, inferBadge } from './taskBrowseHelpers'
 
@@ -59,7 +60,8 @@ export function TaskList() {
         ? pageItems.map((task, index) => {
             const { main } = formatBudget(task)
             const badge = inferBadge(task)
-            const loc = task.location?.trim() || 'Location on request'
+            const loc =
+              taskPublicLocationLabel(task).trim() || 'Location on request'
             return (
               <motion.div
                 key={`${animationCycle}-${task.id}`}

--- a/src/app/(task)/components/(web)/WebLayout.tsx
+++ b/src/app/(task)/components/(web)/WebLayout.tsx
@@ -3,6 +3,7 @@
 import { Badge, Box, HStack, Input, Stack } from '@chakra-ui/react'
 import { Button, Text } from '@ui'
 
+import { formatTaskCategoryLabel } from '@/utils/taskLocationDisplay'
 import {
   useTaskBrowseData,
   useTaskBrowseFiltersProps,
@@ -56,7 +57,9 @@ export function WebLayout() {
     selectedCategorySet.size < categories.length
   ) {
     activeFilterTags.push(
-      ...[...selectedCategorySet].map((cat) => `Category: ${cat}`),
+      ...[...selectedCategorySet].map(
+        (cat) => `Category: ${formatTaskCategoryLabel(cat)}`,
+      ),
     )
   }
   if (sort !== 'nearest') {

--- a/src/app/(task)/context/TaskBrowseProvider.tsx
+++ b/src/app/(task)/context/TaskBrowseProvider.tsx
@@ -16,6 +16,7 @@ import {
   mapboxForwardGeocode,
   mapboxReverseGeocode,
 } from '@/utils/mapboxGeocode'
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 
 import type { SearchThisAreaButtonProps } from '../components/(web)/SearchThisAreaButton'
 import type { UrgencyFilter } from '../components/(web)/TaskBrowseFilters'
@@ -31,11 +32,13 @@ import {
   taskCreatedTime,
 } from '../components/(web)/taskBrowseHelpers'
 
-export const TASK_BROWSE_FILTER_CATEGORIES = [
-  'Plumbing',
-  'Electrical',
-  'Carpentry',
-  'HVAC',
+import { TaskCategory } from '@codegen/schema'
+
+export const TASK_BROWSE_FILTER_CATEGORIES: readonly TaskCategory[] = [
+  TaskCategory.Plumbing,
+  TaskCategory.Electrical,
+  TaskCategory.Painting,
+  TaskCategory.Gardening,
 ] as const
 
 type TaskBrowseDataContextValue = {
@@ -44,9 +47,9 @@ type TaskBrowseDataContextValue = {
   cycleSort: () => void
   page: number
   setPage: (v: number | ((prev: number) => number)) => void
-  selectedCategories: string[]
-  selectedCategorySet: Set<string>
-  toggleCategory: (category: string, checked: boolean) => void
+  selectedCategories: TaskCategory[]
+  selectedCategorySet: Set<TaskCategory>
+  toggleCategory: (category: TaskCategory, checked: boolean) => void
   radiusMiles: number
   setRadiusMiles: (v: number) => void
   minBudget: string
@@ -85,7 +88,7 @@ type TaskBrowseDataContextValue = {
   }[]
   shouldWaitForMap: boolean
   markMapReadyForQuery: (ready: boolean) => void
-  categories: readonly string[]
+  categories: readonly TaskCategory[]
 }
 
 type TaskBrowseLayoutContextValue = {
@@ -147,7 +150,7 @@ export function TaskBrowseProvider({
     })
   const [sort, setSort] = useState<string>('nearest')
   const [page, setPage] = useState(0)
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([
+  const [selectedCategories, setSelectedCategories] = useState<TaskCategory[]>([
     ...TASK_BROWSE_FILTER_CATEGORIES,
   ])
   const [radiusMiles, setRadiusMiles] = useState(10)
@@ -175,7 +178,7 @@ export function TaskBrowseProvider({
   }, [hasMapboxToken])
 
   const selectedCategorySet = useMemo(
-    () => new Set<string>(selectedCategories),
+    () => new Set<TaskCategory>(selectedCategories),
     [selectedCategories],
   )
 
@@ -185,7 +188,7 @@ export function TaskBrowseProvider({
     const minP = minStr === '' ? undefined : Number.parseFloat(minStr) * 100
     const maxP = maxStr === '' ? undefined : Number.parseFloat(maxStr) * 100
     const radius = clampRadiusMiles(radiusMiles)
-    const singleCategory =
+    const singleCategory: TaskCategory | undefined =
       selectedCategories.length === 1 ? selectedCategories[0] : undefined
 
     let dateTimeFrom: string | undefined
@@ -236,7 +239,7 @@ export function TaskBrowseProvider({
 
     return items.filter((task) => {
       if (selectedCategories.length > 0) {
-        const cat = (task.category ?? '').trim()
+        const cat = task.category
         if (cat && !selectedCategorySet.has(cat)) return false
       }
       if (urgency === 'emergency' && !matchesUrgency(task, urgency))
@@ -291,7 +294,7 @@ export function TaskBrowseProvider({
           title: task.title,
           description: task.description,
           category: task.category,
-          location: task.location,
+          location: taskPublicLocationLabel(task),
           locationLat: task.locationLat,
           locationLng: task.locationLng,
           priceLabel: main,
@@ -310,7 +313,7 @@ export function TaskBrowseProvider({
           title: task.title,
           description: task.description,
           category: task.category,
-          location: task.location,
+          location: taskPublicLocationLabel(task),
           locationLat: task.locationLat,
           locationLng: task.locationLng,
           priceLabel: main,
@@ -320,15 +323,18 @@ export function TaskBrowseProvider({
     [initialTasks],
   )
 
-  const toggleCategory = useCallback((category: string, checked: boolean) => {
-    setSelectedCategories((prev) => {
-      const next = new Set(prev)
-      if (checked) next.add(category)
-      else next.delete(category)
-      return [...next]
-    })
-    setPage(0)
-  }, [])
+  const toggleCategory = useCallback(
+    (category: TaskCategory, checked: boolean) => {
+      setSelectedCategories((prev) => {
+        const next = new Set(prev)
+        if (checked) next.add(category)
+        else next.delete(category)
+        return [...next]
+      })
+      setPage(0)
+    },
+    [],
+  )
 
   const setSearchCenter = useCallback((lat: number, lng: number) => {
     setSearchCenterLat(lat)

--- a/src/app/(task)/task/[slug]/page.tsx
+++ b/src/app/(task)/task/[slug]/page.tsx
@@ -1,5 +1,10 @@
 'use client'
 
+import {
+  formatTaskCategoryLabel,
+  formatTaskContactMethodLabel,
+  taskPublicLocationLabel,
+} from '@/utils/taskLocationDisplay'
 import { useMutation, useQuery } from '@apollo/client/react'
 import { Box, Grid, HStack, Link, Stack, VStack } from '@chakra-ui/react'
 import type { AddOfferMutation, MeQuery, TaskQuery } from '@codegen/schema'
@@ -108,6 +113,8 @@ function categoryGradient(category: string): string {
     return 'linear-gradient(135deg, #cb7f08 0%, #855300 100%)'
   if (key.includes('hvac') || key.includes('heat'))
     return 'linear-gradient(135deg, #059669 0%, #047857 100%)'
+  if (key.includes('garden'))
+    return 'linear-gradient(135deg, #22c55e 0%, #15803d 100%)'
   return 'linear-gradient(135deg, #dfe8f7 0%, #b5ceff 100%)'
 }
 
@@ -342,14 +349,14 @@ export default function TaskDetailPage() {
                           <HStack gap={2} color="muted">
                             <IconWrench />
                             <Text fontSize="sm" fontWeight={600} color="fg">
-                              {task.category?.trim() || 'General'}
+                              {formatTaskCategoryLabel(task.category)}
                             </Text>
                           </HStack>
-                          {task.location ? (
+                          {taskPublicLocationLabel(task) ? (
                             <HStack gap={2} color="muted">
                               <IconMapPin />
                               <Text fontSize="sm" fontWeight={600} color="fg">
-                                {task.location}
+                                {taskPublicLocationLabel(task)}
                               </Text>
                             </HStack>
                           ) : null}
@@ -446,7 +453,9 @@ export default function TaskDetailPage() {
                                 <Text as="span" fontWeight={600} color="fg">
                                   Contact:{' '}
                                 </Text>
-                                {task.contactMethod}
+                                {formatTaskContactMethodLabel(
+                                  task.contactMethod,
+                                )}
                               </Text>
                             ) : null}
                           </Stack>
@@ -467,9 +476,7 @@ export default function TaskDetailPage() {
                             gridRow={{ base: 'auto', md: '1 / -1' }}
                             borderRadius="xl"
                             minH={{ base: '160px', md: 'auto' }}
-                            bg={categoryGradient(
-                              task.category?.trim() || 'General',
-                            )}
+                            bg={categoryGradient(task.category)}
                             opacity={0.85}
                             display="flex"
                             alignItems="center"

--- a/src/app/(task)/tasks/create/components/CreateTaskDetailsPanel.tsx
+++ b/src/app/(task)/tasks/create/components/CreateTaskDetailsPanel.tsx
@@ -1,13 +1,19 @@
 'use client'
 
+import { formatTaskCategoryLabel } from '@/utils/taskLocationDisplay'
 import {
   HStack,
   NativeSelect,
   SimpleGrid,
   Stack,
+  Text,
   Textarea,
 } from '@chakra-ui/react'
-import { TaskPaymentMethod } from '@codegen/schema'
+import {
+  type TaskCategory,
+  TaskContactMethod,
+  TaskPaymentMethod,
+} from '@codegen/schema'
 
 import { Button } from '@/ui/Button'
 import { GlassCard } from '@/ui/Card/GlassCard'
@@ -23,42 +29,46 @@ type TimeSlotOption = {
 export type CreateTaskDetailsPanelProps = {
   title: string
   description: string
-  category: string
+  streetAddress: string
+  category: TaskCategory
   preferredDate: string
   preferredTimeSlot: string
-  priceOfferPence: string
-  contactMethod: string
+  budgetMajor: string
+  preferredContactMethod: TaskContactMethod
   paymentMethod: TaskPaymentMethod
-  categoryOptions: readonly string[]
+  categoryOptions: readonly TaskCategory[]
   timeSlotOptions: readonly TimeSlotOption[]
   onTitleChange: (value: string) => void
   onDescriptionChange: (value: string) => void
-  onCategoryChange: (value: string) => void
+  onStreetAddressChange: (value: string) => void
+  onCategoryChange: (value: TaskCategory) => void
   onPreferredDateChange: (value: string) => void
   onPreferredTimeSlotChange: (value: string) => void
-  onPriceOfferPenceChange: (value: string) => void
-  onContactMethodChange: (value: string) => void
+  onBudgetMajorChange: (value: string) => void
+  onPreferredContactMethodChange: (value: TaskContactMethod) => void
   onPaymentMethodChange: (value: TaskPaymentMethod) => void
 }
 
 export function CreateTaskDetailsPanel({
   title,
   description,
+  streetAddress,
   category,
   preferredDate,
   preferredTimeSlot,
-  priceOfferPence,
-  contactMethod,
+  budgetMajor,
+  preferredContactMethod,
   paymentMethod,
   categoryOptions,
   timeSlotOptions,
   onTitleChange,
   onDescriptionChange,
+  onStreetAddressChange,
   onCategoryChange,
   onPreferredDateChange,
   onPreferredTimeSlotChange,
-  onPriceOfferPenceChange,
-  onContactMethodChange,
+  onBudgetMajorChange,
+  onPreferredContactMethodChange,
   onPaymentMethodChange,
 }: CreateTaskDetailsPanelProps) {
   return (
@@ -77,11 +87,24 @@ export function CreateTaskDetailsPanel({
             />
           </FormField>
           <FormField label="Category">
-            <TextInput
-              value={category}
-              onChange={(event) => onCategoryChange(event.target.value)}
-              placeholder="e.g. Plumbing"
-            />
+            <NativeSelect.Root>
+              <NativeSelect.Field
+                bg="surfaceContainerLowest"
+                borderWidth="1px"
+                borderColor="border"
+                borderRadius="lg"
+                value={category}
+                onChange={(event) =>
+                  onCategoryChange(event.target.value as TaskCategory)
+                }
+              >
+                {categoryOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {formatTaskCategoryLabel(option)}
+                  </option>
+                ))}
+              </NativeSelect.Field>
+            </NativeSelect.Root>
           </FormField>
         </SimpleGrid>
 
@@ -95,6 +118,14 @@ export function CreateTaskDetailsPanel({
             borderWidth="1px"
             borderColor="border"
             borderRadius="lg"
+          />
+        </FormField>
+
+        <FormField label="Property address (shared with your tradesperson)">
+          <TextInput
+            value={streetAddress}
+            onChange={(event) => onStreetAddressChange(event.target.value)}
+            placeholder="e.g. 12 Example Street, London E2"
           />
         </FormField>
 
@@ -113,7 +144,7 @@ export function CreateTaskDetailsPanel({
                 boxShadow="none"
                 onClick={() => onCategoryChange(option)}
               >
-                {option}
+                {formatTaskCategoryLabel(option)}
               </Button>
             ))}
           </HStack>
@@ -150,23 +181,88 @@ export function CreateTaskDetailsPanel({
         </SimpleGrid>
 
         <SimpleGrid columns={{ base: 1, md: 2 }} gap={5}>
-          <FormField label="Expected budget (pence)">
+          <FormField label="Expected budget (£)">
             <TextInput
               type="number"
               min={1}
-              value={priceOfferPence}
-              onChange={(event) => onPriceOfferPenceChange(event.target.value)}
-              placeholder="e.g. 4500"
-            />
-          </FormField>
-          <FormField label="Preferred contact method">
-            <TextInput
-              value={contactMethod}
-              onChange={(event) => onContactMethodChange(event.target.value)}
-              placeholder="Phone, WhatsApp, Email"
+              step="0.01"
+              value={budgetMajor}
+              onChange={(event) => onBudgetMajorChange(event.target.value)}
+              placeholder="e.g. 45"
             />
           </FormField>
         </SimpleGrid>
+
+        <FormField label="How should workers reach you?">
+          <Text fontSize="sm" color="muted" mb={2}>
+            We use the contact details saved on your profile when you post.
+          </Text>
+          <HStack gap={2} flexWrap="wrap">
+            <Button
+              type="button"
+              size="sm"
+              variant="subtle"
+              bg={
+                preferredContactMethod === TaskContactMethod.Phone
+                  ? 'secondaryFixed'
+                  : 'surfaceContainerLow'
+              }
+              color={
+                preferredContactMethod === TaskContactMethod.Phone
+                  ? 'onSecondaryFixed'
+                  : 'fg'
+              }
+              boxShadow="none"
+              onClick={() =>
+                onPreferredContactMethodChange(TaskContactMethod.Phone)
+              }
+            >
+              Phone
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="subtle"
+              bg={
+                preferredContactMethod === TaskContactMethod.Email
+                  ? 'secondaryFixed'
+                  : 'surfaceContainerLow'
+              }
+              color={
+                preferredContactMethod === TaskContactMethod.Email
+                  ? 'onSecondaryFixed'
+                  : 'fg'
+              }
+              boxShadow="none"
+              onClick={() =>
+                onPreferredContactMethodChange(TaskContactMethod.Email)
+              }
+            >
+              Email
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="subtle"
+              bg={
+                preferredContactMethod === TaskContactMethod.InApp
+                  ? 'secondaryFixed'
+                  : 'surfaceContainerLow'
+              }
+              color={
+                preferredContactMethod === TaskContactMethod.InApp
+                  ? 'onSecondaryFixed'
+                  : 'fg'
+              }
+              boxShadow="none"
+              onClick={() =>
+                onPreferredContactMethodChange(TaskContactMethod.InApp)
+              }
+            >
+              In app only
+            </Button>
+          </HStack>
+        </FormField>
 
         <FormField label="Payment method">
           <HStack gap={2} flexWrap="wrap">

--- a/src/app/(task)/tasks/create/page.tsx
+++ b/src/app/(task)/tasks/create/page.tsx
@@ -2,6 +2,14 @@
 
 import { useMutation } from '@apollo/client/react'
 import { Box, HStack, Link, SimpleGrid, Stack } from '@chakra-ui/react'
+import {
+  BudgetUnit,
+  type CreateTaskMutation,
+  DayOfWeek,
+  TaskCategory,
+  TaskContactMethod,
+  TaskPaymentMethod,
+} from '@codegen/schema'
 import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
@@ -10,16 +18,14 @@ import { TaskLocationMapPicker } from '@/app/(task)/components'
 import { CREATE_TASK } from '@/graphql/tasks'
 import { getAuthToken } from '@/utils/auth'
 import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
-import { type CreateTaskMutation, TaskPaymentMethod } from '@codegen/schema'
 import { Button, Footer, Header, Heading, Section, Text } from '@ui'
 import { CreateTaskDetailsPanel, CreateTaskSubmitPanel } from './components'
 
 const CATEGORY_OPTIONS = [
-  'Plumbing',
-  'Electrical',
-  'Carpentry',
-  'Painting',
-  'Gardening',
+  TaskCategory.Plumbing,
+  TaskCategory.Electrical,
+  TaskCategory.Painting,
+  TaskCategory.Gardening,
 ] as const
 
 const TIME_SLOT_OPTIONS = [
@@ -28,6 +34,16 @@ const TIME_SLOT_OPTIONS = [
   { value: 'EVENING', label: 'Evening (4pm - 8pm)', hour: '18:00:00' },
   { value: 'ANYTIME', label: 'Anytime', hour: '12:00:00' },
 ] as const
+
+const WEEKDAY_FROM_JS: DayOfWeek[] = [
+  DayOfWeek.Sun,
+  DayOfWeek.Mon,
+  DayOfWeek.Tue,
+  DayOfWeek.Wed,
+  DayOfWeek.Thu,
+  DayOfWeek.Fri,
+  DayOfWeek.Sat,
+]
 
 type MobileStep = 1 | 2 | 3
 
@@ -42,6 +58,12 @@ function toIsoDateTime(preferredDate: string, preferredTimeSlot: string) {
   return parsedDate.toISOString()
 }
 
+function dayOfWeekFromPreferredDate(preferredDate: string): DayOfWeek | null {
+  const parsedDate = new Date(`${preferredDate}T12:00:00`)
+  if (Number.isNaN(parsedDate.getTime())) return null
+  return WEEKDAY_FROM_JS[parsedDate.getDay()] ?? null
+}
+
 export default function CreateTaskPage() {
   const router = useRouter()
   const mapboxAccessToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
@@ -49,17 +71,21 @@ export default function CreateTaskPage() {
   const [mobileStep, setMobileStep] = useState<MobileStep>(1)
   const [title, setTitle] = useState('Fix a leaky tap')
   const [description, setDescription] = useState('Tap leaking under the sink')
-  const [category, setCategory] = useState('Plumbing')
-  const [location, setLocation] = useState('Hackney, London')
+  const [category, setCategory] = useState<TaskCategory>(TaskCategory.Plumbing)
+  const [streetAddress, setStreetAddress] = useState(
+    '12 Example Street, London',
+  )
+  const [mapPlaceName, setMapPlaceName] = useState('Hackney, London')
   const [locationLat, setLocationLat] = useState('51.5416')
   const [locationLng, setLocationLng] = useState('-0.0572')
   const [preferredDate, setPreferredDate] = useState('')
   const [preferredTimeSlot, setPreferredTimeSlot] = useState('MORNING')
-  const [priceOfferPence, setPriceOfferPence] = useState('4500')
+  const [budgetMajor, setBudgetMajor] = useState('45')
   const [paymentMethod, setPaymentMethod] = useState<TaskPaymentMethod>(
     TaskPaymentMethod.Cash,
   )
-  const [contactMethod, setContactMethod] = useState('Phone')
+  const [preferredContactMethod, setPreferredContactMethod] =
+    useState<TaskContactMethod>(TaskContactMethod.Phone)
   const [error, setError] = useState<string | null>(null)
 
   const [runCreateTask, { loading: creating }] =
@@ -71,35 +97,31 @@ export default function CreateTaskPage() {
       setError('Please add a task title.')
       return false
     }
-    if (!category.trim()) {
-      setError('Please choose a category.')
-      return false
-    }
     if (!description.trim()) {
       setError('Please describe what needs to be done.')
+      return false
+    }
+    if (!streetAddress.trim()) {
+      setError('Please add the property address for the tradesperson.')
       return false
     }
     if (!preferredDate) {
       setError('Please provide a preferred date.')
       return false
     }
-    if (!contactMethod.trim()) {
-      setError('Please add a contact method.')
-      return false
-    }
-    const parsedPriceOfferPence = Number.parseInt(priceOfferPence, 10)
-    if (
-      !Number.isFinite(parsedPriceOfferPence) ||
-      Number.isNaN(parsedPriceOfferPence) ||
-      parsedPriceOfferPence <= 0
-    ) {
-      setError('Please provide a valid expected price in pence.')
+    const parsedBudget = Number.parseFloat(budgetMajor)
+    if (!Number.isFinite(parsedBudget) || parsedBudget <= 0) {
+      setError('Please provide a valid budget in pounds.')
       return false
     }
     return true
   }
 
   function validateLocation() {
+    if (!mapPlaceName.trim()) {
+      setError('Please confirm a location on the map (place name).')
+      return false
+    }
     const parsedLocationLat = Number.parseFloat(locationLat)
     const parsedLocationLng = Number.parseFloat(locationLng)
     if (
@@ -129,11 +151,24 @@ export default function CreateTaskPage() {
       return
     }
 
+    const day = dayOfWeekFromPreferredDate(preferredDate)
+    if (!day) {
+      setError('Please provide a valid preferred date.')
+      return
+    }
+
+    const slotConfig = TIME_SLOT_OPTIONS.find(
+      (slot) => slot.value === preferredTimeSlot,
+    )
+    const slotLabel = slotConfig?.label ?? 'Anytime'
+
     if (!getAuthToken()) {
       setError('Please log in before posting a task.')
       router.push(`/login?next=${encodeURIComponent('/tasks/create')}`)
       return
     }
+
+    const parsedBudget = Number.parseFloat(budgetMajor)
 
     try {
       const res = await runCreateTask({
@@ -141,14 +176,20 @@ export default function CreateTaskPage() {
           input: {
             title: title.trim(),
             description: description.trim(),
-            location: location.trim(),
-            locationLat: Number.parseFloat(locationLat),
-            locationLng: Number.parseFloat(locationLng),
-            dateTime: isoDateTime,
-            category: category.trim(),
-            priceOfferPence: Number.parseInt(priceOfferPence, 10),
+            budget: parsedBudget,
+            budgetUnit: BudgetUnit.Gbp,
             paymentMethod,
-            contactMethod: contactMethod.trim(),
+            address: streetAddress.trim(),
+            location: {
+              lat: Number.parseFloat(locationLat),
+              lng: Number.parseFloat(locationLng),
+              name: mapPlaceName.trim(),
+            },
+            category,
+            availability: [{ day, slots: [slotLabel] }],
+            preferredDateTime: isoDateTime,
+            preferredContactMethod,
+            images: [],
           },
         },
       })
@@ -211,30 +252,32 @@ export default function CreateTaskPage() {
                 <CreateTaskDetailsPanel
                   title={title}
                   description={description}
+                  streetAddress={streetAddress}
                   category={category}
                   preferredDate={preferredDate}
                   preferredTimeSlot={preferredTimeSlot}
-                  priceOfferPence={priceOfferPence}
-                  contactMethod={contactMethod}
+                  budgetMajor={budgetMajor}
+                  preferredContactMethod={preferredContactMethod}
                   paymentMethod={paymentMethod}
                   categoryOptions={CATEGORY_OPTIONS}
                   timeSlotOptions={TIME_SLOT_OPTIONS}
                   onTitleChange={setTitle}
                   onDescriptionChange={setDescription}
+                  onStreetAddressChange={setStreetAddress}
                   onCategoryChange={setCategory}
                   onPreferredDateChange={setPreferredDate}
                   onPreferredTimeSlotChange={setPreferredTimeSlot}
-                  onPriceOfferPenceChange={setPriceOfferPence}
-                  onContactMethodChange={setContactMethod}
+                  onBudgetMajorChange={setBudgetMajor}
+                  onPreferredContactMethodChange={setPreferredContactMethod}
                   onPaymentMethodChange={setPaymentMethod}
                 />
                 <Stack gap={6}>
                   <TaskLocationMapPicker
                     accessToken={mapboxAccessToken}
-                    location={location}
+                    location={mapPlaceName}
                     locationLat={locationLat}
                     locationLng={locationLng}
-                    onLocationChange={setLocation}
+                    onLocationChange={setMapPlaceName}
                     onLocationLatChange={setLocationLat}
                     onLocationLngChange={setLocationLng}
                   />
@@ -273,21 +316,23 @@ export default function CreateTaskPage() {
                 <CreateTaskDetailsPanel
                   title={title}
                   description={description}
+                  streetAddress={streetAddress}
                   category={category}
                   preferredDate={preferredDate}
                   preferredTimeSlot={preferredTimeSlot}
-                  priceOfferPence={priceOfferPence}
-                  contactMethod={contactMethod}
+                  budgetMajor={budgetMajor}
+                  preferredContactMethod={preferredContactMethod}
                   paymentMethod={paymentMethod}
                   categoryOptions={CATEGORY_OPTIONS}
                   timeSlotOptions={TIME_SLOT_OPTIONS}
                   onTitleChange={setTitle}
                   onDescriptionChange={setDescription}
+                  onStreetAddressChange={setStreetAddress}
                   onCategoryChange={setCategory}
                   onPreferredDateChange={setPreferredDate}
                   onPreferredTimeSlotChange={setPreferredTimeSlot}
-                  onPriceOfferPenceChange={setPriceOfferPence}
-                  onContactMethodChange={setContactMethod}
+                  onBudgetMajorChange={setBudgetMajor}
+                  onPreferredContactMethodChange={setPreferredContactMethod}
                   onPaymentMethodChange={setPaymentMethod}
                 />
               ) : null}
@@ -295,10 +340,10 @@ export default function CreateTaskPage() {
               {mobileStep === 2 ? (
                 <TaskLocationMapPicker
                   accessToken={mapboxAccessToken}
-                  location={location}
+                  location={mapPlaceName}
                   locationLat={locationLat}
                   locationLng={locationLng}
-                  onLocationChange={setLocation}
+                  onLocationChange={setMapPlaceName}
                   onLocationLatChange={setLocationLat}
                   onLocationLngChange={setLocationLng}
                 />

--- a/src/app/dashboard/context/DashboardDataContext.tsx
+++ b/src/app/dashboard/context/DashboardDataContext.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 import { useQuery } from '@apollo/client/react'
 import type { MeQuery } from '@codegen/schema'
 import {
@@ -266,7 +267,7 @@ export function DashboardDataProvider({
     const posterItems: LiveHistoryItem[] = completedAsPoster.map((task) => ({
       id: `poster-${task.id}`,
       title: task.title,
-      location: task.location ?? 'Location TBC',
+      location: taskPublicLocationLabel(task) || 'Location TBC',
       completedAt: task.createdAt,
       valuePence: task.priceOfferPence ?? 0,
       summary: 'Posted task completed and archived in your customer history.',
@@ -277,7 +278,7 @@ export function DashboardDataProvider({
       ({ task, offer }) => ({
         id: `worker-${offer.id}`,
         title: task.title,
-        location: task.location ?? 'Location TBC',
+        location: taskPublicLocationLabel(task) || 'Location TBC',
         completedAt: offer.createdAt,
         valuePence: offer.pricePence,
         summary: 'Quote progressed to a completed worker engagement.',

--- a/src/app/dashboard/quotes/page.tsx
+++ b/src/app/dashboard/quotes/page.tsx
@@ -11,6 +11,7 @@ import {
   getCategoryVisual,
   isOfferAwarded,
 } from '@/utils/dashboardHelpers'
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 import { Badge, Button, GlassCard, Heading, Text } from '@ui'
 
 function QuoteMetric({
@@ -148,7 +149,7 @@ export default function DashboardQuotesPage() {
                       </Badge>
                     </HStack>
                     <Text fontSize="sm" color="muted">
-                      {task.location ?? 'Location TBC'} ·{' '}
+                      {taskPublicLocationLabel(task) || 'Location TBC'} ·{' '}
                       {formatRelativePosted(offer.createdAt)}
                     </Text>
                     <Text fontSize="sm">

--- a/src/graphql/storage.ts
+++ b/src/graphql/storage.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client'
+
+export const GET_S3_UPLOAD_URL_QUERY = gql`
+  query GetS3UploadUrl($bucket: Bucket!, $key: String!, $index: Int) {
+    getS3UploadUrl(bucket: $bucket, key: $key, index: $index) {
+      url
+    }
+  }
+`

--- a/src/graphql/tasks-query.types.ts
+++ b/src/graphql/tasks-query.types.ts
@@ -1,3 +1,5 @@
+import type { TaskCategory } from '@codegen/schema'
+
 /**
  * Types for task list operations in `tasks.ts`. Prefer `@codegen/schema` once
  * `bun run codegen` succeeds against the GraphQL endpoint.
@@ -12,18 +14,26 @@ export type TaskOfferListItem = {
   createdAt: unknown
 }
 
+export type TaskMapLocationFields = {
+  lat?: number | null
+  lng?: number | null
+  name?: string | null
+}
+
 export type TaskListItem = {
   id: string
   title: string
   description: string
-  location?: string | null
+  address?: string | null
+  locationName?: string | null
+  location?: TaskMapLocationFields | null
   locationLat?: number | null
   locationLng?: number | null
   status: string
   createdByUserId: string
   createdAt: unknown
   dateTime?: unknown
-  category?: string | null
+  category?: TaskCategory | null
   priceOfferPence?: number | null
   paymentMethod?: string | null
   contactMethod?: string | null

--- a/src/graphql/tasks.ts
+++ b/src/graphql/tasks.ts
@@ -6,9 +6,15 @@ export const CREATE_TASK = gql`
       id
       title
       description
-      location
+      address
+      location {
+        lat
+        lng
+        name
+      }
       locationLat
       locationLng
+      locationName
       dateTime
       category
       priceOfferPence
@@ -34,7 +40,7 @@ export const TASKS_QUERY = gql`
     $lng: Float
     $radiusMiles: Float
     $search: String
-    $category: String
+    $category: TaskCategory
     $minPricePence: Int
     $maxPricePence: Int
     $dateTimeFrom: DateTime
@@ -54,9 +60,15 @@ export const TASKS_QUERY = gql`
       id
       title
       description
-      location
+      address
+      location {
+        lat
+        lng
+        name
+      }
       locationLat
       locationLng
+      locationName
       status
       createdByUserId
       createdAt
@@ -84,7 +96,15 @@ export const TASK_QUERY = gql`
       id
       title
       description
-      location
+      address
+      location {
+        lat
+        lng
+        name
+      }
+      locationLat
+      locationLng
+      locationName
       status
       createdByUserId
       createdAt
@@ -112,7 +132,7 @@ export const BROWSE_TASKS_QUERY = gql`
     $lng: Float
     $radiusMiles: Float
     $search: String
-    $category: String
+    $category: TaskCategory
     $minPricePence: Int
     $maxPricePence: Int
     $dateTimeFrom: DateTime
@@ -132,9 +152,15 @@ export const BROWSE_TASKS_QUERY = gql`
       id
       title
       description
-      location
+      address
+      location {
+        lat
+        lng
+        name
+      }
       locationLat
       locationLng
+      locationName
       status
       priceOfferPence
       createdAt
@@ -149,9 +175,15 @@ export const MY_TASKS_QUERY = gql`
       id
       title
       description
-      location
+      address
+      location {
+        lat
+        lng
+        name
+      }
       locationLat
       locationLng
+      locationName
       status
       createdByUserId
       createdAt
@@ -254,17 +286,6 @@ export const MARK_TASK_COMPLETE_MUTATION = gql`
       id
       status
       completedAt
-    }
-  }
-`
-
-export const POST_TASK_MUTATION = gql`
-  mutation PostTask($input: PostTaskInput!) {
-    postTask(input: $input) {
-      id
-      title
-      description
-      status
     }
   }
 `

--- a/src/utils/dashboardHelpers.ts
+++ b/src/utils/dashboardHelpers.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import type { MyTasksQueryData } from '@/graphql/tasks-query.types'
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 
 export function getDisplayNameFromEmail(email: string | null | undefined) {
   const localPart = (email ?? '').split('@')[0]?.trim()
@@ -88,7 +89,7 @@ export function matchesSearch(task: TaskItem, q: string) {
   return (
     task.title.toLowerCase().includes(search) ||
     (task.description ?? '').toLowerCase().includes(search) ||
-    (task.location ?? '').toLowerCase().includes(search) ||
+    taskPublicLocationLabel(task).toLowerCase().includes(search) ||
     (task.category ?? '').toLowerCase().includes(search)
   )
 }
@@ -126,6 +127,13 @@ export function getCategoryVisual(category: string | null | undefined) {
     return {
       glyph: '🎨',
       bg: 'linear-gradient(135deg, #fff4e4 0%, #ffddb8 100%)',
+    }
+  }
+
+  if (key.includes('garden')) {
+    return {
+      glyph: '🌿',
+      bg: 'linear-gradient(135deg, #e8fff0 0%, #b8f0c8 100%)',
     }
   }
 

--- a/src/utils/taskLocationDisplay.ts
+++ b/src/utils/taskLocationDisplay.ts
@@ -1,0 +1,30 @@
+import type { TaskCategory } from '@codegen/schema'
+
+/** Title-case label for `TaskCategory` enum values in UI copy. */
+export function formatTaskCategoryLabel(category: TaskCategory): string {
+  return category
+    .split('_')
+    .map((w) => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ')
+}
+
+/** Human-readable label for `TaskContactMethod` stored as a string on `Task`. */
+export function formatTaskContactMethodLabel(method: string): string {
+  const key = method.trim().toUpperCase().replaceAll(' ', '_')
+  if (key === 'PHONE') return 'Phone'
+  if (key === 'EMAIL') return 'Email'
+  if (key === 'IN_APP') return 'In app'
+  return method
+}
+
+/** Public-facing place line for lists and maps (address omitted when API hides it). */
+export function taskPublicLocationLabel(task: {
+  locationName?: string | null
+  location?: { name?: string | null } | null
+  address?: string | null
+}): string {
+  const fromName =
+    task.locationName?.trim() || task.location?.name?.trim() || ''
+  if (fromName) return fromName
+  return task.address?.trim() || ''
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the web app with the backend task API described in BE-11: `createTask` input shape, composite `location`, `TaskCategory` on `tasks` search, removal of `postTask`, and location discovery via `locationName` / `location.name`.

## Changes

- **GraphQL (`src/graphql/tasks.ts`)**: Removed `postTask`. Task queries/mutations now select `address`, `location { lat lng name }`, and `locationName`. `tasks` / `BrowseTasks` use `$category: TaskCategory`.
- **Storage (`src/graphql/storage.ts`)**: Added `getS3UploadUrl` query matching the API (`Bucket`, `key`, optional `index`) for future task image uploads.
- **Create task flow**: Sends `budget` + `budgetUnit` (GBP), free-text `address`, `location` with Mapbox place `name`, `TaskCategory`, `availability` (weekday from preferred date + slot label), optional `preferredDateTime`, and `preferredContactMethod` (PHONE / EMAIL / IN_APP). Map picker still drives place name and coordinates separately from street address.
- **Browse & lists**: Filter categories match API enums (Plumbing, Electrical, Painting, Gardening). Public location copy uses `taskPublicLocationLabel()` so browse respects obfuscated place names vs full address when the API returns them.
- **Helpers**: `src/utils/taskLocationDisplay.ts` for display labels.

## Verification

- `npx graphql-codegen --config codegen.ts` (against live schema in agent env)
- `npx tsc --noEmit`
- `npx biome check --write .` (equivalent to project lint when Bun is unavailable)

Note: `.codegen/schema.ts` remains gitignored; run `bun run codegen` after pull with valid `NEXT_PUBLIC_GRAPHQL_URL` and `SCHEMA_ACCESS_TOKEN`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BE-11](https://linear.app/slashie/issue/BE-11/implemented-be-changes)

<div><a href="https://cursor.com/agents/bc-0d40ed39-93d9-427b-b9e9-c7a539523ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d40ed39-93d9-427b-b9e9-c7a539523ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

