### PR TITLE
docs: update AGENTS.md codegen instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Single Next.js 16 frontend app (no local backend/DB). All data comes from an ext
 
 - **Bun is the package manager.** The lockfile is `bun.lock`. Always use `bun install` and `bun run <script>`.
 - **`lefthook install` fails** if `core.hooksPath` is set by the agent environment. Use `bun install --ignore-scripts` when you only need dependencies, then run `lefthook install --force` separately if git hooks are needed.
-- **`.codegen/schema.ts` is gitignored** and the `.codegen/` directory ships empty. The remote codegen endpoint requires an `apollo-require-preflight` header that the current `codegen.ts` config does not send, so `bun run codegen` may fail with a CSRF error. Workaround: restore the schema from git history (`git show 7c39d98:.codegen/schema.ts > .codegen/schema.ts`). When codegen is fixed upstream, prefer running `bun run codegen`.
+- **`.codegen/schema.ts` is gitignored** and the `.codegen/` directory ships empty. Run `bun run codegen` to generate it (requires `.env` with `NEXT_PUBLIC_GRAPHQL_URL` and `SCHEMA_ACCESS_TOKEN`). If codegen fails, fall back to restoring from git history: `git show 7c39d98:.codegen/schema.ts > .codegen/schema.ts` (note: the historical schema may be stale and missing newer types).
 - **`.env` is gitignored.** The update script recreates it from injected environment secrets (`NEXT_PUBLIC_GRAPHQL_URL`, `SCHEMA_ACCESS_TOKEN`, `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`). See `.env.example` for the full list.
 - **`bun run dev`** runs `exports-gen` (barrel file generation) automatically before starting Next.js, so you don't need to run it separately for dev.
 - **`bun run lint`** runs Biome with `--write` (auto-fix + format). It modifies files in place.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@chakra-ui/react": "^3.32.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hookform/resolvers": "^5.2.2",
         "embla-carousel-react": "^8.6.0",
         "embla-carousel-wheel-gestures": "^8.1.0",
         "graphql": "^16.12.0",
@@ -18,6 +19,8 @@
         "posthog-js": "^1.360.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-hook-form": "^7.72.1",
+        "zod": "^4.3.6",
         "zustand": "^5.0.12",
       },
       "devDependencies": {
@@ -286,6 +289,8 @@
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
+
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -535,6 +540,8 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@storybook/addon-a11y": ["@storybook/addon-a11y@10.2.4", "", { "dependencies": { "@storybook/global": "^5.0.0", "axe-core": "^4.2.0" }, "peerDependencies": { "storybook": "^10.2.4" } }, "sha512-VGhdZ+iP2l/CSulIKV2kt3SMWVHntOigqWqGkNYf6YNYofynUYEKdsNqBvHx4ySuNEl/eXJ8LRO8FKYnU7LxZQ=="],
 
@@ -1308,6 +1315,8 @@
 
     "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
 
+    "react-hook-form": ["react-hook-form@7.72.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig=="],
+
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
@@ -1513,6 +1522,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 

--- a/src/app/(task)/components/index.ts
+++ b/src/app/(task)/components/index.ts
@@ -3,17 +3,7 @@
  * Run `bun run exports-gen` to regenerate this barrel.
  */
 
-export {
-  effectiveTaskPricePenceForFilter,
-  endOfLocalDay,
-  formatBudget,
-  inferBadge,
-  matchesUrgency,
-  PAGE_SIZE,
-  SORT_OPTIONS,
-  startOfLocalDay,
-  taskCreatedTime,
-} from './(web)/taskBrowseHelpers'
+export { effectiveTaskPricePenceForFilter, endOfLocalDay, formatBudget, inferBadge, matchesUrgency, PAGE_SIZE, SORT_OPTIONS, startOfLocalDay, taskCreatedTime } from './(web)/taskBrowseHelpers'
 export { MobileLayout } from './(mobile)/MobileLayout'
 export { MobileTaskCarousel } from './(mobile)/MobileTaskCarousel'
 export { SearchThisAreaButton } from './(web)/SearchThisAreaButton'
@@ -23,15 +13,8 @@ export { TaskList } from './(web)/TaskList'
 export { TaskLocationMapPicker } from './(web)/TaskLocationMapPicker'
 export { TaskMap } from './(web)/TaskMap'
 export { WebLayout } from './(web)/WebLayout'
-export type {
-  JobCardBadgeVariant,
-  TaskBrowseListCardTask,
-  TaskBrowseListItemProps,
-} from './(web)/TaskBrowseListItem'
+export type { JobCardBadgeVariant, TaskBrowseListCardTask, TaskBrowseListItemProps } from './(web)/TaskBrowseListItem'
 export type { SearchThisAreaButtonProps } from './(web)/SearchThisAreaButton'
-export type {
-  TaskBrowseFiltersProps,
-  UrgencyFilter,
-} from './(web)/TaskBrowseFilters'
+export type { TaskBrowseFiltersProps, UrgencyFilter } from './(web)/TaskBrowseFilters'
 export type { TaskLocationMapPickerProps } from './(web)/TaskLocationMapPicker'
 export type { TaskMapProps, TaskMapTask } from './(web)/TaskMap'

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -11,14 +11,7 @@ export { Dock } from './Dock'
 export { FormField } from './FormField/FormField'
 export { GlassCard } from './Card/GlassCard'
 export { HandyBoxWordmark } from './HandyBoxWordmark/HandyBoxWordmark'
-export {
-  IconCalendar,
-  IconClock,
-  IconDocument,
-  IconMapPin,
-  IconSliders,
-  IconWrench,
-} from './TaskBrowseMetaIcons'
+export { IconCalendar, IconClock, IconDocument, IconMapPin, IconSliders, IconWrench } from './TaskBrowseMetaIcons'
 export { Input, TextInput } from './Input'
 export * from './Footer'
 export * from './Header'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates from development environment setup:

1. **`AGENTS.md`** — Updated codegen instructions: `bun run codegen` now works (CSRF issue resolved). Git-history fallback retained with a staleness warning.
2. **`bun.lock`** — Synced lockfile with `package.json` (added `@hookform/resolvers`, `react-hook-form`, `zod` resolutions that were missing).
3. **Barrel exports** — Regenerated `src/ui/index.ts` and `src/app/(task)/components/index.ts` via `bun run exports-gen`.

## Environment Setup Verification

[handybox_homepage_browse_demo.mp4](https://cursor.com/agents/bc-2a99f40e-3768-4e6d-b7b2-12509b0a1b06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhandybox_homepage_browse_demo.mp4)

[Homepage with task listings and map](https://cursor.com/agents/bc-2a99f40e-3768-4e6d-b7b2-12509b0a1b06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_task_listings.webp)
[Task detail page](https://cursor.com/agents/bc-2a99f40e-3768-4e6d-b7b2-12509b0a1b06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftask_detail_page.webp)
[Login redirect for protected routes](https://cursor.com/agents/bc-2a99f40e-3768-4e6d-b7b2-12509b0a1b06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_redirect_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a99f40e-3768-4e6d-b7b2-12509b0a1b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a99f40e-3768-4e6d-b7b2-12509b0a1b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

