### PR TITLE
fix(task): guest quote panel and pence validation (BE-9)

### DIFF
--- a/src/app/(task)/task/[slug]/components/TaskDetailWorkerSidebar.tsx
+++ b/src/app/(task)/task/[slug]/components/TaskDetailWorkerSidebar.tsx
@@ -87,6 +87,8 @@ export type TaskDetailWorkerQuotePanelProps = {
     message?: string | null
     status: QuoteStatus
   } | null
+  /** Used when the visitor is not signed in: primary CTA to authenticate before quoting. */
+  signInHref: string
   canAccessWorkerTools: boolean
   mePresent: boolean
   pricePence: string
@@ -101,6 +103,7 @@ export type TaskDetailWorkerQuotePanelProps = {
 
 export function TaskDetailWorkerQuotePanel({
   myQuote,
+  signInHref,
   canAccessWorkerTools,
   mePresent,
   pricePence,
@@ -125,6 +128,24 @@ export function TaskDetailWorkerQuotePanel({
             <Badge bg="surfaceContainerLow" color="fg" w="fit-content">
               Status: {normaliseStatus(myQuote.status)}
             </Badge>
+          </Stack>
+        </GlassCard>
+      ) : !mePresent ? (
+        <GlassCard
+          p={6}
+          bg="surfaceContainerLow"
+          borderColor="border"
+          boxShadow="ambient"
+        >
+          <Stack gap={4}>
+            <Heading size="md">Sign in to submit a quote</Heading>
+            <Text color="muted">
+              Log in with a worker account to send your price and message to the
+              client.
+            </Text>
+            <Button as={NextLink} href={signInHref} w="full">
+              Sign in
+            </Button>
           </Stack>
         </GlassCard>
       ) : mePresent && !canAccessWorkerTools ? (
@@ -153,7 +174,7 @@ export function TaskDetailWorkerQuotePanel({
             </Text>
             <Stack gap={3}>
               <TextInput
-                placeholder="Quote price (pence)"
+                placeholder="Quote in pence (e.g. 5000 = £50)"
                 value={pricePence}
                 onChange={(e) => onPriceChange(e.target.value)}
               />

--- a/src/app/(task)/task/[slug]/page.tsx
+++ b/src/app/(task)/task/[slug]/page.tsx
@@ -184,12 +184,18 @@ export default function TaskDetailPage() {
       return
     }
 
+    const parsedPence = Number.parseInt(pricePence.trim(), 10)
+    if (!Number.isFinite(parsedPence) || parsedPence < 1) {
+      setQuoteError('Enter a valid quote in whole pence (minimum 1).')
+      return
+    }
+
     try {
       const res = await addQuote({
         variables: {
           input: {
             taskId: task.id,
-            pricePence: Number(pricePence) || 0,
+            pricePence: parsedPence,
             message: message || undefined,
           },
         },
@@ -388,6 +394,9 @@ export default function TaskDetailPage() {
                         <TaskDetailApproximateLocation task={task} />
                         <TaskDetailWorkerQuotePanel
                           myQuote={myQuote}
+                          signInHref={`/login?next=${encodeURIComponent(
+                            `/task/${task.id}#task-quote`,
+                          )}`}
                           canAccessWorkerTools={canAccessWorkerTools}
                           mePresent={Boolean(me)}
                           pricePence={pricePence}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Linear BE-9 is scoped to the Apollo API; this PR addresses **frontend** task-detail behaviour that was inconsistent with “must be logged in (and a worker) to quote”.

## Changes

- **Guest visitors** on task detail no longer see the full “Submit a quote” form. They get a **Sign in** card with the same return URL as the existing submit handler (`/task/:id#task-quote`).
- **Quote submission** now rejects empty or non-integer / sub-1 pence values before calling `addQuote`, avoiding silent `0` pence quotes from `Number('') || 0`.
- **Placeholder** text clarifies that the amount is in **pence** (e.g. 5000 = £50).

## Testing

- Not run: `bun` is unavailable in this agent environment; `@biomejs/biome@1.9.4 check` was run on the touched files.

## Copy-paste changelog for API / cross-team

See the final assistant message in the issue thread for the full **text changelog** the PM asked for (backend + FE follow-ups).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BE-9](https://linear.app/slashie/issue/BE-9/making-quote-to-a-task-flow)

<div><a href="https://cursor.com/agents/bc-e741d07f-b8c2-4191-91f8-d5611674ef0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e741d07f-b8c2-4191-91f8-d5611674ef0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

