### PR TITLE
FE-29: Unify task detail on task(id); remove taskWorkflow

### DIFF
--- a/src/app/(task)/task/[slug]/page.tsx
+++ b/src/app/(task)/task/[slug]/page.tsx
@@ -102,7 +102,9 @@ export default function TaskDetailPage() {
 
   const task = data?.task
 
-  const isOwner = Boolean(me && task && me.id === task.createdByUserId)
+  const isOwner = Boolean(
+    me && task && (me.id === task.createdByUserId || me.id === task.poster?.id),
+  )
   const myQuote = useMemo(() => {
     if (!me || !task) return null
     return task.quotes.find((o) => o.workerUserId === me.id) ?? null
@@ -114,8 +116,12 @@ export default function TaskDetailPage() {
       return
     }
 
-    setWorkerProfileEnabled(getWorkerRegistered(me.id) || Boolean(myQuote))
-  }, [me, myQuote])
+    setWorkerProfileEnabled(
+      getWorkerRegistered(me.id) ||
+        Boolean(myQuote) ||
+        Boolean(task && me && task.workerUserId === me.id),
+    )
+  }, [me, myQuote, task])
 
   const sortedQuotes = useMemo(() => {
     if (!task) return []
@@ -228,7 +234,10 @@ export default function TaskDetailPage() {
   const canAcceptQuotes = Boolean(
     isOwner && task && task.status === TaskStatus.Open,
   )
-  const canAccessWorkerTools = Boolean(workerProfileEnabled || myQuote)
+  const isAssignedWorker = Boolean(me && task && task.workerUserId === me.id)
+  const canAccessWorkerTools = Boolean(
+    workerProfileEnabled || myQuote || isAssignedWorker,
+  )
 
   const introSubtitle = useMemo(() => {
     if (!taskId) return null

--- a/src/graphql/tasks-query.types.ts
+++ b/src/graphql/tasks-query.types.ts
@@ -30,7 +30,8 @@ export type TaskListItem = {
   locationLat?: number | null
   locationLng?: number | null
   status: string
-  createdByUserId: string
+  /** Present for poster-owned rows; omitted/redacted on public `tasks` list hits. */
+  createdByUserId?: string | null
   createdAt: unknown
   dateTime?: unknown
   category?: TaskCategory | null
@@ -38,6 +39,7 @@ export type TaskListItem = {
   paymentMethod?: string | null
   contactMethod?: string | null
   images?: string[] | null
+  /** Visitor-shaped `tasks` hits return an empty list; poster views include quotes. */
   quotes: TaskQuoteListItem[]
 }
 

--- a/src/graphql/tasks.ts
+++ b/src/graphql/tasks.ts
@@ -61,7 +61,6 @@ export const TASKS_QUERY = gql`
       id
       title
       description
-      address
       location {
         lat
         lng
@@ -71,13 +70,11 @@ export const TASKS_QUERY = gql`
       locationLng
       locationName
       status
-      createdByUserId
       createdAt
       dateTime
       category
       priceQuotePence
       paymentMethod
-      contactMethod
       images
       quotes {
         id
@@ -108,8 +105,12 @@ export const TASK_QUERY = gql`
       locationLng
       locationName
       status
+      workerUserId
+      selectedQuoteId
       createdByUserId
       createdAt
+      completedAt
+      confirmedAt
       dateTime
       category
       priceQuotePence
@@ -123,6 +124,43 @@ export const TASK_QUERY = gql`
       availability {
         day
         slots
+      }
+      poster {
+        id
+        firstName
+        lastName
+        profile {
+          name
+        }
+      }
+      selectedQuote {
+        id
+        pricePence
+        message
+        workerUserId
+        status
+        createdAt
+      }
+      review {
+        id
+        rating
+        comment
+        createdAt
+        workerUserId
+        reviewer {
+          id
+          firstName
+          lastName
+          profile {
+            name
+          }
+        }
+      }
+      comments {
+        id
+        body
+        createdAt
+        userId
       }
       quotes {
         id
@@ -213,20 +251,6 @@ export const MY_TASKS_QUERY = gql`
         message
         status
         createdAt
-      }
-    }
-  }
-`
-
-export const TASK_WORKFLOW_QUERY = gql`
-  query TaskWorkflow($id: ID!) {
-    taskWorkflow(id: $id) {
-      id
-      status
-      quotes {
-        id
-        status
-        pricePence
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the frontend with the backend change that removes `taskWorkflow` and serves all task detail through `task(id)` with role-based field visibility.

## Changes

- Removed the unused `TASK_WORKFLOW_QUERY` operation.
- **`TASKS_QUERY`**: Dropped visitor-redacted selections (`address`, `createdByUserId`, `contactMethod`) while keeping `quotes { … }` so the response shape stays consistent (visitor list returns an empty quotes list per API behaviour).
- **`TASK_QUERY`**: Requested workflow and collaboration fields the schema now documents on `task(id)` (`workerUserId`, `selectedQuoteId`, `completedAt`, `confirmedAt`, `poster`, `selectedQuote`, `review`, `comments`, plus existing quote/budget/availability data).
- **`TaskListItem`**: `createdByUserId` is optional to match public list rows.
- **Task detail page**: Owner detection falls back to `poster.id` when `createdByUserId` is redacted; assigned workers are treated as eligible for worker tools (sidebar) even without a stored quote.

## Verification

- `npx graphql-codegen --config codegen.ts` succeeds against the live schema.
- `npx tsc --noEmit` passes.

Note: `.codegen/schema.ts` remains gitignored; run `bun run codegen` (or `npx graphql-codegen`) locally after pulling.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-29](https://linear.app/slashie/issue/FE-29/unify-task-detail-on-taskid-remove-taskworkflow)

<div><a href="https://cursor.com/agents/bc-6c9783f7-bf69-4bee-95f1-f2789f9a93e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c9783f7-bf69-4bee-95f1-f2789f9a93e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

