### PR TITLE
FE-30: Quote visibility, browse query, and monthly connection limit messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You sign up as a **worker**, add skills and profile details, then **browse tasks
 
 ### Connections and membership
 
-Unlike marketplaces that charge a **service fee on every job**, Slashie lets workers **reach customers for free within a monthly time-limited allowance** (the allowance **renews each month**). Workers who need more volume can **subscribe to a membership** for **unlimited connections**.
+Unlike marketplaces that charge a **service fee on every job**, Slashie lets workers **reach customers for free within a monthly time-limited allowance** (the allowance **renews each month**, measured in **UTC**; the free tier currently allows **3 quote connections per calendar month** unless you have paid membership or Worker Pro). Workers who need more volume can **subscribe to a membership** for **unlimited connections**.
 
 ### Map-first discovery
 

--- a/src/app/(customer)/context/CustomerAccountContext.tsx
+++ b/src/app/(customer)/context/CustomerAccountContext.tsx
@@ -11,13 +11,14 @@ import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
 
 import {
   type TaskItem,
+  type TaskQuoteItem,
   isTaskCompleted,
   timeFromUnknown,
 } from '@/utils/dashboardHelpers'
 
 export type IncomingQuoteRow = {
   task: TaskItem
-  quote: TaskItem['quotes'][number]
+  quote: TaskQuoteItem
 }
 
 type CustomerAccountContextValue = {
@@ -75,7 +76,7 @@ export function CustomerAccountProvider({
       )
 
     const rows: IncomingQuoteRow[] = posted.flatMap((task) =>
-      task.quotes.map((quote) => ({ task, quote })),
+      (task.quotes ?? []).map((quote) => ({ task, quote })),
     )
     rows.sort(
       (a, b) =>

--- a/src/app/(customer)/requests/page.tsx
+++ b/src/app/(customer)/requests/page.tsx
@@ -40,7 +40,7 @@ const FILTER_LABELS: Record<RequestFilter, string> = {
 function getTaskStage(task: TaskItem): TaskStage {
   if (isTaskCompleted(task.status)) return 'completed'
   if (isQuoteAwarded(task.status)) return 'awarded'
-  if (task.quotes.length === 0) return 'draft'
+  if ((task.quotes ?? []).length === 0) return 'draft'
   return 'open'
 }
 
@@ -48,7 +48,7 @@ function TaskCard({ task }: { task: TaskItem }) {
   const stage = getTaskStage(task)
   const visual = getCategoryVisual(task.category)
   const amount =
-    getQuoteRange(task.quotes) ?? formatPounds(task.priceQuotePence ?? 0)
+    getQuoteRange(task.quotes ?? []) ?? formatPounds(task.priceQuotePence ?? 0)
 
   const badgeByStage: Record<TaskStage, { bg: string; color: string }> = {
     draft: { bg: 'surfaceContainerHigh', color: 'muted' },
@@ -163,11 +163,11 @@ export default function CustomerRequestsPage() {
   )
 
   const quoteActivityCount = useMemo(
-    () => activeTasks.filter((t) => t.quotes.length > 0).length,
+    () => activeTasks.filter((t) => (t.quotes ?? []).length > 0).length,
     [activeTasks],
   )
   const totalQuotes = useMemo(
-    () => myPostedTasks.reduce((n, t) => n + t.quotes.length, 0),
+    () => myPostedTasks.reduce((n, t) => n + (t.quotes ?? []).length, 0),
     [myPostedTasks],
   )
 
@@ -297,7 +297,7 @@ export default function CustomerRequestsPage() {
               </Heading>
               <Stack gap={3}>
                 {activeTasks
-                  .filter((task) => task.quotes.length > 0)
+                  .filter((task) => (task.quotes ?? []).length > 0)
                   .slice(0, 3)
                   .map((task) => (
                     <GlassCard
@@ -309,7 +309,7 @@ export default function CustomerRequestsPage() {
                     >
                       <Heading size="sm">{task.title}</Heading>
                       <Text fontSize="sm" color="muted">
-                        {task.quotes.length} quotes {'•'}{' '}
+                        {(task.quotes ?? []).length} quotes {'•'}{' '}
                         {taskPublicLocationLabel(task) || 'Location TBC'}
                       </Text>
                       <Link

--- a/src/app/(task)/helpers/taskBrowseHelpers.ts
+++ b/src/app/(task)/helpers/taskBrowseHelpers.ts
@@ -31,7 +31,7 @@ export function formatBudget(task: TaskListItem): {
       sub: 'Fixed price',
     }
   }
-  const quotes = task.quotes
+  const quotes = task.quotes ?? []
   if (quotes.length === 0) {
     return { main: 'Open', sub: 'Estimated budget' }
   }
@@ -88,7 +88,7 @@ export function effectiveTaskPricePenceForFilter(
 ): number | null {
   const fixed = task.priceQuotePence
   if (fixed != null && fixed > 0) return fixed
-  const quotes = task.quotes
+  const quotes = task.quotes ?? []
   if (!quotes.length) return null
   return Math.min(...quotes.map((o) => o.pricePence))
 }

--- a/src/app/(task)/task/[slug]/components/TaskDetailHero.tsx
+++ b/src/app/(task)/task/[slug]/components/TaskDetailHero.tsx
@@ -7,19 +7,27 @@ import {
 import { Box, Grid, Stack } from '@chakra-ui/react'
 import { GlassCard, Text } from '@ui'
 
-import { type TaskDetailRecord, taskBudgetDisplayLine } from './taskDetailUtils'
+import {
+  type TaskBudgetViewerContext,
+  type TaskDetailRecord,
+  taskBudgetDisplayLine,
+} from './taskDetailUtils'
 
 export type TaskDetailHeroProps = {
   task: TaskDetailRecord
   statusBadgeLabel: string
+  budgetViewer: TaskBudgetViewerContext
+  viewerUserId?: string | null
 }
 
 export function TaskDetailHero({
   task,
   statusBadgeLabel,
+  budgetViewer,
+  viewerUserId,
 }: TaskDetailHeroProps) {
   const locationLine = taskPublicLocationLabel(task)
-  const budgetLine = taskBudgetDisplayLine(task)
+  const budgetLine = taskBudgetDisplayLine(task, budgetViewer, viewerUserId)
 
   return (
     <GlassCard p={{ base: 5, md: 6 }} borderColor="border" boxShadow="ambient">

--- a/src/app/(task)/task/[slug]/components/taskDetailUtils.ts
+++ b/src/app/(task)/task/[slug]/components/taskDetailUtils.ts
@@ -17,9 +17,24 @@ function formatMajorGbp(amount: number) {
   return `£${amount.toFixed(0)}`
 }
 
-/** Hero budget line: quote range, posted budget range, fixed quote pence, or open. */
-export function taskBudgetDisplayLine(task: TaskDetailRecord): string {
-  const { quotes } = task
+export type TaskBudgetViewerContext = 'owner' | 'visitor'
+
+/**
+ * Hero budget line: quote range (role-aware), posted budget range, fixed quote pence, or open.
+ * For visitors, only the signed-in worker's own quotes count toward the range so competitor
+ * prices are not inferred from `task.quotes`.
+ */
+export function taskBudgetDisplayLine(
+  task: TaskDetailRecord,
+  viewer: TaskBudgetViewerContext,
+  viewerUserId?: string | null,
+): string {
+  const quotes =
+    viewer === 'owner'
+      ? task.quotes
+      : viewerUserId
+        ? task.quotes.filter((q) => q.workerUserId === viewerUserId)
+        : []
   if (quotes.length > 0) {
     const prices = quotes.map((q) => q.pricePence)
     const min = Math.min(...prices)

--- a/src/app/(task)/task/[slug]/page.tsx
+++ b/src/app/(task)/task/[slug]/page.tsx
@@ -258,6 +258,8 @@ export default function TaskDetailPage() {
         <TaskDetailHero
           task={t}
           statusBadgeLabel={taskStatusBadgeLabel(t.status)}
+          budgetViewer="visitor"
+          viewerUserId={me?.id ?? null}
         />
         <TaskDetailPhotoGrid task={t} />
         <TaskDetailDescriptionCard task={t} />

--- a/src/app/dashboard/context/DashboardDataContext.tsx
+++ b/src/app/dashboard/context/DashboardDataContext.tsx
@@ -205,7 +205,7 @@ export function DashboardDataProvider({
 
     const submitted = tasks
       .flatMap((task) =>
-        task.quotes
+        (task.quotes ?? [])
           .filter((quote) => quote.workerUserId === me.id)
           .map((quote) => ({ task, quote })),
       )
@@ -216,7 +216,7 @@ export function DashboardDataProvider({
       )
 
     const quoteCount = posted.reduce(
-      (count, task) => count + task.quotes.length,
+      (count, task) => count + (task.quotes ?? []).length,
       0,
     )
 
@@ -294,7 +294,7 @@ export function DashboardDataProvider({
   const customerBookings = useMemo(
     () =>
       activePostedTasks
-        .filter((task) => task.quotes.length > 0)
+        .filter((task) => (task.quotes ?? []).length > 0)
         .sort(
           (a, b) => timeFromUnknown(b.createdAt) - timeFromUnknown(a.createdAt),
         ),

--- a/src/graphql/tasks-query.types.ts
+++ b/src/graphql/tasks-query.types.ts
@@ -39,8 +39,11 @@ export type TaskListItem = {
   paymentMethod?: string | null
   contactMethod?: string | null
   images?: string[] | null
-  /** Visitor-shaped `tasks` hits return an empty list; poster views include quotes. */
-  quotes: TaskQuoteListItem[]
+  /**
+   * Only present when the operation selects `quotes` (e.g. `myTasks`).
+   * Public `tasks` browse does not fetch quotes.
+   */
+  quotes?: TaskQuoteListItem[]
 }
 
 export type TasksQueryData = {

--- a/src/graphql/tasks.ts
+++ b/src/graphql/tasks.ts
@@ -76,15 +76,6 @@ export const TASKS_QUERY = gql`
       priceQuotePence
       paymentMethod
       images
-      quotes {
-        id
-        taskId
-        workerUserId
-        pricePence
-        message
-        status
-        createdAt
-      }
     }
   }
 `

--- a/src/utils/dashboardHelpers.ts
+++ b/src/utils/dashboardHelpers.ts
@@ -15,7 +15,7 @@ export function getDisplayNameFromEmail(email: string | null | undefined) {
 }
 
 export type TaskItem = MyTasksQueryData['myTasks'][number]
-export type TaskQuoteItem = TaskItem['quotes'][number]
+export type TaskQuoteItem = NonNullable<TaskItem['quotes']>[number]
 export type MyQuoteItem = {
   task: TaskItem
   quote: TaskQuoteItem

--- a/src/utils/graphqlErrors.ts
+++ b/src/utils/graphqlErrors.ts
@@ -12,7 +12,12 @@ const FRIENDLY_ERROR_BY_MESSAGE: Record<string, string> = {
   INVALID_CREDENTIALS: 'Email or password is incorrect.',
   WEAK_PASSWORD: 'Password must meet the minimum complexity requirements.',
   INVALID_OR_EXPIRED_RESET_TOKEN: 'This reset link is invalid or has expired.',
+  MONTHLY_CONNECTION_LIMIT_REACHED:
+    "You've reached the free limit of 3 quote connections this calendar month (UTC). Upgrade your membership or Worker Pro for unlimited connections, or try again next month.",
 }
+
+export const MONTHLY_CONNECTION_LIMIT_ERROR_CODE =
+  'MONTHLY_CONNECTION_LIMIT_REACHED' as const
 
 function normaliseMessage(message: string) {
   return message.trim().toUpperCase()
@@ -42,8 +47,23 @@ export function isUnauthenticatedError(error: unknown) {
   return normaliseMessage(graphQLError.message) === 'UNAUTHENTICATED'
 }
 
+export function isMonthlyConnectionLimitError(error: unknown) {
+  const graphQLError = pickGraphQLError(error)
+  if (graphQLError?.extensions?.code === MONTHLY_CONNECTION_LIMIT_ERROR_CODE)
+    return true
+  if (!graphQLError?.message) return false
+  return (
+    normaliseMessage(graphQLError.message) ===
+    MONTHLY_CONNECTION_LIMIT_ERROR_CODE
+  )
+}
+
 export function getFriendlyErrorMessage(error: unknown, fallback: string) {
   const graphQLError = pickGraphQLError(error)
+  const code = graphQLError?.extensions?.code
+  if (code === MONTHLY_CONNECTION_LIMIT_ERROR_CODE) {
+    return FRIENDLY_ERROR_BY_MESSAGE[MONTHLY_CONNECTION_LIMIT_ERROR_CODE]
+  }
   if (graphQLError?.message) {
     const normalisedMessage = normaliseMessage(graphQLError.message)
     const mappedMessage = FRIENDLY_ERROR_BY_MESSAGE[normalisedMessage]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements frontend alignment for the backend changes in FE-30: role-scoped `task.quotes`, free-tier **3 connections per UTC month**, and clearer UX when the cap is hit.

## Changes

- **Public browse (`TASKS_QUERY`)**: Removed the `quotes` selection so the map/list no longer receives competitor quote payloads (matches server behaviour where non-owners should not see others’ quotes). Budget helpers already treat an empty list as “open”.
- **Task detail (visitors)**: `taskBudgetDisplayLine` now takes a viewer context; for non-owners it only considers **the signed-in user’s** quotes when deriving a range, so the hero “budget” line does not leak competitor prices from `task.quotes`.
- **Errors**: `getFriendlyErrorMessage` maps `MONTHLY_CONNECTION_LIMIT_REACHED` (extensions code or message) to copy that states the **3/month UTC** limit and points workers toward membership / Worker Pro.
- **Types / consumers**: `TaskListItem.quotes` is optional where the query omits it; customer requests and dashboard code use `task.quotes ?? []`. `TaskQuoteItem` is derived with `NonNullable`.
- **Docs**: README “Connections and membership” now mentions the **3/month UTC** free allowance.

## Not done in this PR

- **`bun run codegen`**: No `.env` / schema endpoint in this agent environment; run codegen locally or in CI after pointing at the updated API so `@codegen/schema` and any doc strings stay in sync.

## Testing

- Ran Biome on touched files. Full `tsc` was not reliable here (stale local `.codegen/schema.ts` snapshot vs current operations); CI should validate types after codegen.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-30](https://linear.app/slashie/issue/FE-30/free-tier-quote-cap-3month-and-task-detail-quotes-visibility)

<div><a href="https://cursor.com/agents/bc-c7689f19-e135-44a7-82b3-f40ad42c62b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7689f19-e135-44a7-82b3-f40ad42c62b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

