### PR TITLE
FE-31: Stop treating quotes as completed worker onboarding

### DIFF
--- a/src/app/(task)/task/[slug]/page.tsx
+++ b/src/app/(task)/task/[slug]/page.tsx
@@ -12,7 +12,7 @@ import type {
 import { TaskStatus } from '@codegen/schema'
 import NextLink from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { ME_QUERY } from '@/graphql/auth'
 import {
@@ -77,8 +77,6 @@ export default function TaskDetailPage() {
   const [acceptError, setAcceptError] = useState<string | null>(null)
   const [acceptingQuoteId, setAcceptingQuoteId] = useState<string | null>(null)
   const [cancelError, setCancelError] = useState<string | null>(null)
-  const [workerProfileEnabled, setWorkerProfileEnabled] = useState(false)
-
   const hasToken = typeof window !== 'undefined' && Boolean(getAuthToken())
 
   const { data: meData } = useQuery<MeQuery>(ME_QUERY, {
@@ -110,18 +108,7 @@ export default function TaskDetailPage() {
     return task.quotes.find((o) => o.workerUserId === me.id) ?? null
   }, [me, task])
 
-  useEffect(() => {
-    if (!me) {
-      setWorkerProfileEnabled(false)
-      return
-    }
-
-    setWorkerProfileEnabled(
-      getWorkerRegistered(me.id) ||
-        Boolean(myQuote) ||
-        Boolean(task && me && task.workerUserId === me.id),
-    )
-  }, [me, myQuote, task])
+  const workerOnboardingDone = Boolean(me && getWorkerRegistered(me.id))
 
   const sortedQuotes = useMemo(() => {
     if (!task) return []
@@ -184,7 +171,7 @@ export default function TaskDetailPage() {
       return
     }
 
-    if (!workerProfileEnabled && !myQuote) {
+    if (!workerOnboardingDone && !myQuote) {
       setQuoteError('Create a worker profile before submitting quotes.')
       router.push('/dashboard/worker/register')
       return
@@ -236,7 +223,7 @@ export default function TaskDetailPage() {
   )
   const isAssignedWorker = Boolean(me && task && task.workerUserId === me.id)
   const canAccessWorkerTools = Boolean(
-    workerProfileEnabled || myQuote || isAssignedWorker,
+    workerOnboardingDone || myQuote || isAssignedWorker,
   )
 
   const introSubtitle = useMemo(() => {

--- a/src/app/dashboard/components/DashboardShell.tsx
+++ b/src/app/dashboard/components/DashboardShell.tsx
@@ -23,6 +23,8 @@ export type DashboardShellProps = {
   userStatus?: string
   userMeta?: string
   workerEnabled?: boolean
+  /** When set, sidebar promo reflects onboarding; nav locking still uses workerEnabled. */
+  workerProfileComplete?: boolean
   workerCtaHref?: string
   headerAction?: React.ReactNode
   children: React.ReactNode
@@ -247,10 +249,13 @@ export function DashboardShell({
   userStatus,
   userMeta,
   workerEnabled = false,
+  workerProfileComplete,
   workerCtaHref = '/dashboard/worker/register',
   headerAction,
   children,
 }: DashboardShellProps) {
+  const workerOnboardingDone = workerProfileComplete ?? workerEnabled
+
   return (
     <Box minH="100vh" bg="bg" color="fg">
       <Stack
@@ -379,33 +384,38 @@ export function DashboardShell({
             <GlassCard
               p={4}
               bg={
-                workerEnabled
+                workerOnboardingDone
                   ? 'linear-gradient(160deg, #03225a 0%, #012b73 55%, #00358f 100%)'
                   : 'primary.50'
               }
-              color={workerEnabled ? 'white' : 'fg'}
+              color={workerOnboardingDone ? 'white' : 'fg'}
             >
               <Stack gap={3}>
                 <Text
                   fontSize="10px"
                   fontWeight={800}
                   letterSpacing="0.08em"
-                  color={workerEnabled ? 'whiteAlpha.800' : 'primary.700'}
+                  color={
+                    workerOnboardingDone ? 'whiteAlpha.800' : 'primary.700'
+                  }
                 >
-                  {workerEnabled
+                  {workerOnboardingDone
                     ? 'WORKER MODE ACTIVE'
                     : 'WORKER FEATURES LOCKED'}
                 </Text>
-                <Heading size="sm" color={workerEnabled ? 'white' : undefined}>
-                  {workerEnabled
-                    ? 'Quotes and earnings are unlocked.'
+                <Heading
+                  size="sm"
+                  color={workerOnboardingDone ? 'white' : undefined}
+                >
+                  {workerOnboardingDone
+                    ? 'Your worker profile is set up.'
                     : 'Become a worker to send quotes.'}
                 </Heading>
                 <Text
                   fontSize="sm"
-                  color={workerEnabled ? 'whiteAlpha.900' : 'muted'}
+                  color={workerOnboardingDone ? 'whiteAlpha.900' : 'muted'}
                 >
-                  {workerEnabled
+                  {workerOnboardingDone
                     ? 'Track active quotes, monitor payout totals, and keep your professional profile ready for new work.'
                     : 'Create your worker profile to unlock quoting, task intake, and payout tracking in the dashboard.'}
                 </Text>
@@ -413,12 +423,14 @@ export function DashboardShell({
                   as={NextLink}
                   href={workerCtaHref}
                   size="sm"
-                  variant={workerEnabled ? 'subtle' : 'solid'}
-                  bg={workerEnabled ? 'whiteAlpha.200' : undefined}
-                  color={workerEnabled ? 'white' : undefined}
+                  variant={workerOnboardingDone ? 'subtle' : 'solid'}
+                  bg={workerOnboardingDone ? 'whiteAlpha.200' : undefined}
+                  color={workerOnboardingDone ? 'white' : undefined}
                   alignSelf="flex-start"
                 >
-                  {workerEnabled ? 'Manage worker profile' : 'Become a worker'}
+                  {workerOnboardingDone
+                    ? 'Manage worker profile'
+                    : 'Become a worker'}
                 </Button>
               </Stack>
             </GlassCard>

--- a/src/app/dashboard/context/DashboardDataContext.tsx
+++ b/src/app/dashboard/context/DashboardDataContext.tsx
@@ -98,6 +98,8 @@ type DashboardDataContextValue = {
   userInitial: string
   profile: DashboardProfile
   workerProfile: DashboardWorkerProfile
+  /** Session/onboarding worker profile is complete (not inferred from quote activity). */
+  workerProfileComplete: boolean
   workerEnabled: boolean
   serviceHistory: ServiceHistoryEntry[]
   workerServiceHistory: ServiceHistoryEntry[]
@@ -326,11 +328,11 @@ export function DashboardDataProvider({
 
   const userInitial = displayName.charAt(0)?.toUpperCase() || '?'
 
-  const workerEnabled = Boolean(
-    workerProfile.isActive ||
-      myQuotes.length > 0 ||
-      (me ? getWorkerRegistered(me.id) : false),
+  const workerProfileComplete = Boolean(
+    workerProfile.isActive || (me ? getWorkerRegistered(me.id) : false),
   )
+
+  const workerEnabled = Boolean(workerProfileComplete || myQuotes.length > 0)
 
   const serviceHistory = useMemo(
     () => completedHistoryItems.map(toHistoryEntry),
@@ -412,6 +414,7 @@ export function DashboardDataProvider({
         preferredTrades: [],
       },
       workerProfile,
+      workerProfileComplete,
       workerEnabled,
       serviceHistory,
       workerServiceHistory,
@@ -464,6 +467,7 @@ export function DashboardDataProvider({
       userInitial,
       workerEnabled,
       workerProfile,
+      workerProfileComplete,
       setSearch,
     ],
   )

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -39,6 +39,7 @@ function DashboardChrome({ children }: { children: React.ReactNode }) {
     displayName,
     userInitial,
     workerEnabled,
+    workerProfileComplete,
   } = useDashboardData()
 
   if (!meLoading && !me) {
@@ -98,10 +99,15 @@ function DashboardChrome({ children }: { children: React.ReactNode }) {
       userLabel={displayName}
       userInitial={userInitial}
       userStatus={
-        workerEnabled ? 'Worker tools unlocked' : 'Complete worker setup'
+        workerProfileComplete
+          ? 'Worker tools unlocked'
+          : workerEnabled
+            ? 'Finish worker profile'
+            : 'Complete worker setup'
       }
       userMeta={me?.email ?? ''}
       workerEnabled={workerEnabled}
+      workerProfileComplete={workerProfileComplete}
       headerAction={
         <HStack gap={2} flexWrap="wrap">
           <Button

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -43,6 +43,7 @@ export default function DashboardOverviewPage() {
     tasksErrorMessage,
     displayName,
     workerEnabled,
+    workerProfileComplete,
     workerProfile,
     myQuotes,
     quotesInProgress,
@@ -91,7 +92,11 @@ export default function DashboardOverviewPage() {
                 {workerProfile.serviceArea?.trim() || 'Set service area'}
               </Badge>
               <Badge bg="primary.50" color="primary.700">
-                {workerEnabled ? 'Quoting enabled' : 'Complete worker setup'}
+                {workerProfileComplete
+                  ? 'Quoting enabled'
+                  : workerEnabled
+                    ? 'Finish worker profile'
+                    : 'Complete worker setup'}
               </Badge>
             </HStack>
           </Stack>

--- a/src/app/dashboard/worker/register/page.tsx
+++ b/src/app/dashboard/worker/register/page.tsx
@@ -20,8 +20,13 @@ import { Badge, Button, GlassCard, Heading, Text, TextInput } from '@ui'
 
 export default function WorkerRegistrationPage() {
   const router = useRouter()
-  const { profile, workerProfile, registerWorker, saveProfile, workerEnabled } =
-    useDashboardData()
+  const {
+    profile,
+    workerProfile,
+    registerWorker,
+    saveProfile,
+    workerProfileComplete,
+  } = useDashboardData()
 
   const [fullName, setFullName] = useState(profile.fullName)
   const [phoneNumber, setPhoneNumber] = useState(profile.phoneNumber)
@@ -90,9 +95,11 @@ export default function WorkerRegistrationPage() {
       <Stack gap={2}>
         <HStack gap={3} flexWrap="wrap">
           <Heading size="xl">
-            {workerEnabled ? 'Manage worker profile' : 'Become a worker'}
+            {workerProfileComplete
+              ? 'Manage worker profile'
+              : 'Become a worker'}
           </Heading>
-          {workerEnabled ? (
+          {workerProfileComplete ? (
             <Badge bg="primary.50" color="primary.700">
               Active since{' '}
               {workerProfile.joinedAt
@@ -312,7 +319,9 @@ export default function WorkerRegistrationPage() {
                 </HStack>
               </Stack>
               <Button onClick={() => handleSubmit()}>
-                {workerEnabled ? 'Update worker profile' : 'Join HandyBox'}
+                {workerProfileComplete
+                  ? 'Update worker profile'
+                  : 'Join HandyBox'}
               </Button>
             </Stack>
           </GlassCard>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The API can create a worker profile as a side effect of quote mutations. The app was inferring “worker profile enabled” from **having any quote**, which let users skip the explicit worker onboarding flow and still see the quote form on task detail.

## Changes

- **Task detail:** Quote gating and “worker tools” access now require **session onboarding** (`getWorkerRegistered`) unless the user already has a quote **on this task** or is the assigned worker. Having a quote elsewhere no longer unlocks quoting on new tasks.
- **Dashboard:** Introduced `workerProfileComplete` (session/onboarding only) while keeping `workerEnabled` true when the user has quotes so **Quotes / Earnings** stay reachable. Updated shell promo copy and overview badge to distinguish “finish worker profile” from full unlock.

## Testing

- Ran `biome check --write` on touched files (local `node_modules`).
- Full `tsc` was not run against a checked-in schema (`.codegen/schema.ts` is gitignored in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-31](https://linear.app/slashie/issue/FE-31/fe-ticket-quote-mutations-auto-create-missing-worker-profile)

<div><a href="https://cursor.com/agents/bc-0a38964b-a368-44de-be3f-ddf37470843f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a38964b-a368-44de-be3f-ddf37470843f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

