### PR TITLE
Rebuild unified account hub shell and overview dashboard

### DIFF
--- a/src/app/(dashboard)/components/AccountShell.tsx
+++ b/src/app/(dashboard)/components/AccountShell.tsx
@@ -1,69 +1,259 @@
 'use client'
 
-import { Box, Container, Grid, Heading, Stack, Text } from '@chakra-ui/react'
+import {
+  Avatar,
+  Box,
+  HStack,
+  IconButton as ChakraIconButton,
+  Link,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
+import type { ReactNode } from 'react'
 
-import { Header } from '@ui'
+import { Button, Input, Logo } from '@ui'
+
+import { type MeSnapshot, useUserStore } from '@/app/(auth)/store/user'
 
 import { resolveAccountNavKey } from '../helpers/accountNav'
-import { AccountSideNav, AccountTabStrip } from './AccountSideNav'
+import { AccountBottomNav, AccountSideNav } from './AccountSideNav'
 
 type AccountShellProps = {
-  children: React.ReactNode
+  children: ReactNode
 }
 
-/**
- * Merged customer + worker account shell. Composes the canonical site Header
- * plus an in-area side nav (desktop) / tab strip (mobile). Auth gating + me
- * hydration are handled by the route group `layout.tsx`.
- */
+function SearchIcon() {
+  return (
+    <Box as="span" display="inline-flex" aria-hidden>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+        <path
+          d="M11 4a7 7 0 1 1 0 14 7 7 0 0 1 0-14Zm8.5 16.5-4-4"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </Box>
+  )
+}
+
+function MessageIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M4 6h16v10H7l-3 3V6Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function BellIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M6 16h12l-1.5-2.2v-3.5a4.5 4.5 0 0 0-9 0v3.5L6 16Zm4 2a2 2 0 0 0 4 0"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function completionFromMe(
+  me: MeSnapshot,
+) {
+  const checks = [
+    Boolean(me.profile?.name?.trim()),
+    Boolean(me.profile?.contactNumber?.trim()),
+    Boolean(me.worker?.id),
+    Boolean(me.worker?.tagline?.trim()),
+    Boolean(me.worker?.locationAddress?.trim()),
+  ]
+  const done = checks.filter(Boolean).length
+  const total = checks.length
+  const percent = Math.round((done / total) * 100)
+  return {
+    percent,
+    done,
+    total,
+    isWorker: Boolean(me.worker?.id),
+  }
+}
+
+/** Unified account hub shell with desktop rail + mobile bottom navigation. */
 export function AccountShell({ children }: AccountShellProps) {
   const pathname = usePathname()
   const active = resolveAccountNavKey(pathname)
+  const me = useUserStore((state) => state.me)
+  if (!me) return null
+  const completion = completionFromMe(me)
+  const profileName =
+    me.profile?.name?.trim() ||
+    `${me.firstName ?? ''} ${me.lastName ?? ''}`.trim() ||
+    me.email.split('@')[0] ||
+    'Member'
+  const profileLinkLabel = completion.isWorker ? 'Manage profile' : 'Continue setup'
+  const profileLinkHref = completion.isWorker ? '/profile' : '/worker/setup'
 
   return (
     <Box minH="100dvh" bg="neutral.100" color="cardFg">
-      <Header />
-      <Box display={{ base: 'block', lg: 'none' }}>
-        <AccountTabStrip active={active} />
-      </Box>
-      <Container
-        maxW="container.xl"
-        px={{ base: 4, md: 6 }}
-        py={{ base: 6, md: 8 }}
+      <Box
+        display={{ base: 'none', lg: 'block' }}
+        w="280px"
+        borderRightWidth="1px"
+        borderColor="cardBorder"
+        bg="bg"
+        position="fixed"
+        insetY={0}
+        left={0}
       >
-        <Grid
-          templateColumns={{ base: '1fr', lg: '240px 1fr' }}
-          gap={{ base: 0, lg: 8 }}
-          alignItems="start"
-        >
-          <Box
-            display={{ base: 'none', lg: 'block' }}
-            position="sticky"
-            top={4}
-          >
-            <Stack
-              gap={4}
-              p={4}
-              bg="cardBg"
-              borderRadius="xl"
-              borderWidth="1px"
-              borderColor="cardBorder"
-            >
-              <Stack gap={0}>
-                <Heading size="sm" color="cardFg">
-                  Account hub
-                </Heading>
-                <Text fontSize="xs" color="formLabelMuted">
-                  Customer + worker tools in one workspace.
+        <Stack h="full" py={6} px={5} gap={6}>
+          <Link as={NextLink} href="/" _hover={{ textDecoration: 'none' }}>
+            <Logo />
+          </Link>
+
+          <AccountSideNav active={active} />
+
+          <Box mt="auto" display="grid" gap={4}>
+            <Stack p={4} gap={3} bg="primary.100" borderRadius="xl">
+              <Stack gap={0.5}>
+                <Text fontSize="sm" fontWeight={700}>
+                  Complete your profile
+                </Text>
+                <Text fontSize="xs" color="green.800">
+                  Stand out and get more work.
                 </Text>
               </Stack>
-              <AccountSideNav active={active} />
+
+              <Stack gap={2}>
+                <HStack justify="space-between">
+                  <Text fontSize="xs" color="green.800">
+                    {completion.done}/{completion.total} complete
+                  </Text>
+                  <Text fontSize="xs" color="green.800" fontWeight={700}>
+                    {completion.percent}%
+                  </Text>
+                </HStack>
+                <Box h="6px" borderRadius="full" bg="whiteAlpha.700" overflow="hidden">
+                  <Box h="full" bg="primary.600" w={`${completion.percent}%`} />
+                </Box>
+              </Stack>
+
+              <Link
+                as={NextLink}
+                href={profileLinkHref}
+                _hover={{ textDecoration: 'none' }}
+              >
+                <Button size="sm" w="full">
+                  {profileLinkLabel}
+                </Button>
+              </Link>
             </Stack>
+
+            <Text fontSize="xs" color="formLabelMuted">
+              Payments are arranged directly between customer and worker outside
+              Slashie.
+            </Text>
           </Box>
-          <Box minW={0}>{children}</Box>
-        </Grid>
-      </Container>
+        </Stack>
+      </Box>
+
+      <Box
+        minH="100dvh"
+        pl={{ base: 0, lg: '280px' }}
+        display="grid"
+        gridTemplateRows="auto 1fr"
+      >
+        <Box
+          as="header"
+          borderBottomWidth="1px"
+          borderColor="cardBorder"
+          bg="bg"
+          px={{ base: 4, md: 6 }}
+          py={3}
+          position="sticky"
+          top={0}
+          zIndex={20}
+        >
+          <HStack gap={3} justify="space-between" align="center">
+            <Box display={{ base: 'none', md: 'block' }} flex="1" maxW="520px">
+              <Input
+                startElement={<SearchIcon />}
+                aria-label="Search account hub"
+                placeholder="Search tasks, requests, people..."
+              />
+            </Box>
+            <Link
+              as={NextLink}
+              href="/"
+              _hover={{ textDecoration: 'none' }}
+              display={{ base: 'block', md: 'none' }}
+            >
+              <Logo />
+            </Link>
+            <HStack gap={2}>
+              <ChakraIconButton
+                aria-label="Messages"
+                variant="ghost"
+                size="sm"
+                color="formLabelMuted"
+                bg="badgeBg"
+              >
+                <MessageIcon />
+              </ChakraIconButton>
+              <ChakraIconButton
+                aria-label="Notifications"
+                variant="ghost"
+                size="sm"
+                color="formLabelMuted"
+                bg="badgeBg"
+              >
+                <BellIcon />
+              </ChakraIconButton>
+              <Link
+                as={NextLink}
+                href="/profile"
+                _hover={{ textDecoration: 'none' }}
+                display="flex"
+                alignItems="center"
+                gap={2}
+                borderRadius="full"
+                px={1}
+              >
+                <Avatar
+                  size="sm"
+                  name={profileName}
+                  src={me.profile?.avatarUrl ?? undefined}
+                />
+                <Text
+                  display={{ base: 'none', md: 'block' }}
+                  fontSize="sm"
+                  fontWeight={600}
+                  maxW="120px"
+                  truncate
+                >
+                  {profileName}
+                </Text>
+              </Link>
+            </HStack>
+          </HStack>
+        </Box>
+
+        <Box px={{ base: 4, md: 6, xl: 8 }} py={{ base: 5, md: 6 }} pb={{ base: 24, lg: 8 }}>
+          {children}
+        </Box>
+      </Box>
+
+      <AccountBottomNav active={active} />
     </Box>
   )
 }

--- a/src/app/(dashboard)/components/AccountShell.tsx
+++ b/src/app/(dashboard)/components/AccountShell.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import {
-  Avatar,
   Box,
-  HStack,
   IconButton as ChakraIconButton,
+  HStack,
+  Image,
   Link,
   Stack,
   Text,
@@ -28,6 +28,7 @@ function SearchIcon() {
   return (
     <Box as="span" display="inline-flex" aria-hidden>
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+        <title>Search</title>
         <path
           d="M11 4a7 7 0 1 1 0 14 7 7 0 0 1 0-14Zm8.5 16.5-4-4"
           stroke="currentColor"
@@ -43,6 +44,7 @@ function SearchIcon() {
 function MessageIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <title>Messages</title>
       <path
         d="M4 6h16v10H7l-3 3V6Z"
         stroke="currentColor"
@@ -57,6 +59,7 @@ function MessageIcon() {
 function BellIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <title>Notifications</title>
       <path
         d="M6 16h12l-1.5-2.2v-3.5a4.5 4.5 0 0 0-9 0v3.5L6 16Zm4 2a2 2 0 0 0 4 0"
         stroke="currentColor"
@@ -68,9 +71,7 @@ function BellIcon() {
   )
 }
 
-function completionFromMe(
-  me: MeSnapshot,
-) {
+function completionFromMe(me: MeSnapshot) {
   const checks = [
     Boolean(me.profile?.name?.trim()),
     Boolean(me.profile?.contactNumber?.trim()),
@@ -101,7 +102,10 @@ export function AccountShell({ children }: AccountShellProps) {
     `${me.firstName ?? ''} ${me.lastName ?? ''}`.trim() ||
     me.email.split('@')[0] ||
     'Member'
-  const profileLinkLabel = completion.isWorker ? 'Manage profile' : 'Continue setup'
+  const profileInitial = profileName.charAt(0).toUpperCase() || 'S'
+  const profileLinkLabel = completion.isWorker
+    ? 'Manage profile'
+    : 'Continue setup'
   const profileLinkHref = completion.isWorker ? '/profile' : '/worker/setup'
 
   return (
@@ -143,7 +147,12 @@ export function AccountShell({ children }: AccountShellProps) {
                     {completion.percent}%
                   </Text>
                 </HStack>
-                <Box h="6px" borderRadius="full" bg="whiteAlpha.700" overflow="hidden">
+                <Box
+                  h="6px"
+                  borderRadius="full"
+                  bg="whiteAlpha.700"
+                  overflow="hidden"
+                >
                   <Box h="full" bg="primary.600" w={`${completion.percent}%`} />
                 </Box>
               </Stack>
@@ -229,11 +238,31 @@ export function AccountShell({ children }: AccountShellProps) {
                 borderRadius="full"
                 px={1}
               >
-                <Avatar
-                  size="sm"
-                  name={profileName}
-                  src={me.profile?.avatarUrl ?? undefined}
-                />
+                <Box
+                  w={8}
+                  h={8}
+                  borderRadius="full"
+                  bg="primary.100"
+                  color="primary.700"
+                  display="grid"
+                  placeItems="center"
+                  fontSize="sm"
+                  fontWeight={700}
+                  overflow="hidden"
+                  flexShrink={0}
+                >
+                  {me.profile?.avatarUrl ? (
+                    <Image
+                      src={me.profile.avatarUrl}
+                      alt={`${profileName} avatar`}
+                      w="full"
+                      h="full"
+                      objectFit="cover"
+                    />
+                  ) : (
+                    profileInitial
+                  )}
+                </Box>
                 <Text
                   display={{ base: 'none', md: 'block' }}
                   fontSize="sm"
@@ -248,7 +277,11 @@ export function AccountShell({ children }: AccountShellProps) {
           </HStack>
         </Box>
 
-        <Box px={{ base: 4, md: 6, xl: 8 }} py={{ base: 5, md: 6 }} pb={{ base: 24, lg: 8 }}>
+        <Box
+          px={{ base: 4, md: 6, xl: 8 }}
+          py={{ base: 5, md: 6 }}
+          pb={{ base: 24, lg: 8 }}
+        >
           {children}
         </Box>
       </Box>

--- a/src/app/(dashboard)/components/AccountSideNav.tsx
+++ b/src/app/(dashboard)/components/AccountSideNav.tsx
@@ -20,6 +20,7 @@ function NavIcon({ type }: { type: AccountNavKey }) {
   if (type === 'overview') {
     return (
       <svg {...common} aria-hidden>
+        <title>Overview</title>
         <path
           d="M4 13.5L12 5l8 8.5M7 11.5V19h10v-7.5"
           stroke="currentColor"
@@ -34,6 +35,7 @@ function NavIcon({ type }: { type: AccountNavKey }) {
   if (type === 'requests') {
     return (
       <svg {...common} aria-hidden>
+        <title>My Requests</title>
         <path
           d="M7 4h10l3 3v13H4V4h3Zm10 0v3h3"
           stroke="currentColor"
@@ -48,6 +50,7 @@ function NavIcon({ type }: { type: AccountNavKey }) {
   if (type === 'jobs') {
     return (
       <svg {...common} aria-hidden>
+        <title>Jobs</title>
         <path
           d="M4 8h16v11H4V8Zm4-3h8v3H8V5Z"
           stroke="currentColor"
@@ -62,6 +65,7 @@ function NavIcon({ type }: { type: AccountNavKey }) {
   if (type === 'earnings') {
     return (
       <svg {...common} aria-hidden>
+        <title>Earnings</title>
         <path
           d="M12 3a9 9 0 1 0 9 9"
           stroke="currentColor"
@@ -82,7 +86,14 @@ function NavIcon({ type }: { type: AccountNavKey }) {
   if (type === 'account') {
     return (
       <svg {...common} aria-hidden>
-        <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.8" />
+        <title>Account</title>
+        <circle
+          cx="12"
+          cy="12"
+          r="8.5"
+          stroke="currentColor"
+          strokeWidth="1.8"
+        />
         <path
           d="M12 9.3a2.2 2.2 0 1 1 0 4.4 2.2 2.2 0 0 1 0-4.4Z"
           stroke="currentColor"
@@ -94,6 +105,7 @@ function NavIcon({ type }: { type: AccountNavKey }) {
 
   return (
     <svg {...common} aria-hidden>
+      <title>Profile</title>
       <circle cx="12" cy="8" r="3.2" stroke="currentColor" strokeWidth="1.8" />
       <path
         d="M5.5 19c.8-2.6 3.1-4.2 6.5-4.2s5.7 1.6 6.5 4.2"
@@ -131,7 +143,10 @@ export function AccountSideNav({ active }: AccountSideNavProps) {
               bg: isActive ? 'primary.100' : 'badgeBg',
             }}
           >
-            <Box display="flex" color={isActive ? 'primary.700' : 'formLabelMuted'}>
+            <Box
+              display="flex"
+              color={isActive ? 'primary.700' : 'formLabelMuted'}
+            >
               <NavIcon type={item.key} />
             </Box>
             <Text>{item.label}</Text>
@@ -184,7 +199,11 @@ export function AccountBottomNav({ active }: AccountSideNavProps) {
               color={isActive ? 'primary.700' : 'formLabelMuted'}
             >
               <NavIcon type={item.key} />
-              <Text fontSize="xs" fontWeight={isActive ? 700 : 600} lineHeight={1}>
+              <Text
+                fontSize="xs"
+                fontWeight={isActive ? 700 : 600}
+                lineHeight={1}
+              >
                 {item.label}
               </Text>
             </Stack>

--- a/src/app/(dashboard)/components/AccountSideNav.tsx
+++ b/src/app/(dashboard)/components/AccountSideNav.tsx
@@ -9,7 +9,103 @@ type AccountSideNavProps = {
   active: AccountNavKey
 }
 
-/** Desktop side nav for the merged account hub (mobile uses tab strip). */
+function NavIcon({ type }: { type: AccountNavKey }) {
+  const common = {
+    width: 18,
+    height: 18,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+  } as const
+
+  if (type === 'overview') {
+    return (
+      <svg {...common} aria-hidden>
+        <path
+          d="M4 13.5L12 5l8 8.5M7 11.5V19h10v-7.5"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+
+  if (type === 'requests') {
+    return (
+      <svg {...common} aria-hidden>
+        <path
+          d="M7 4h10l3 3v13H4V4h3Zm10 0v3h3"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+
+  if (type === 'jobs') {
+    return (
+      <svg {...common} aria-hidden>
+        <path
+          d="M4 8h16v11H4V8Zm4-3h8v3H8V5Z"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+
+  if (type === 'earnings') {
+    return (
+      <svg {...common} aria-hidden>
+        <path
+          d="M12 3a9 9 0 1 0 9 9"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+        <path
+          d="M12 7v6l4 2"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+
+  if (type === 'account') {
+    return (
+      <svg {...common} aria-hidden>
+        <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.8" />
+        <path
+          d="M12 9.3a2.2 2.2 0 1 1 0 4.4 2.2 2.2 0 0 1 0-4.4Z"
+          stroke="currentColor"
+          strokeWidth="1.8"
+        />
+      </svg>
+    )
+  }
+
+  return (
+    <svg {...common} aria-hidden>
+      <circle cx="12" cy="8" r="3.2" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M5.5 19c.8-2.6 3.1-4.2 6.5-4.2s5.7 1.6 6.5 4.2"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+/** Desktop side nav for the merged account hub. */
 export function AccountSideNav({ active }: AccountSideNavProps) {
   return (
     <Stack as="nav" aria-label="Account sections" gap={1} w="full">
@@ -32,16 +128,12 @@ export function AccountSideNav({ active }: AccountSideNavProps) {
             fontSize="sm"
             _hover={{
               textDecoration: 'none',
-              bg: isActive ? 'primary.100' : 'cardBg',
+              bg: isActive ? 'primary.100' : 'badgeBg',
             }}
           >
-            <Box
-              w={2}
-              h={2}
-              borderRadius="full"
-              bg={isActive ? 'primary.600' : 'transparent'}
-              aria-hidden
-            />
+            <Box display="flex" color={isActive ? 'primary.700' : 'formLabelMuted'}>
+              <NavIcon type={item.key} />
+            </Box>
             <Text>{item.label}</Text>
           </Link>
         )
@@ -50,23 +142,25 @@ export function AccountSideNav({ active }: AccountSideNavProps) {
   )
 }
 
-/** Mobile horizontal tab strip used above page content. */
-export function AccountTabStrip({ active }: AccountSideNavProps) {
+/** Mobile in-dashboard navigation with parity to desktop sections. */
+export function AccountBottomNav({ active }: AccountSideNavProps) {
   return (
     <HStack
       as="nav"
       aria-label="Account sections"
-      gap={2}
-      overflowX="auto"
-      px={4}
-      py={2}
-      borderBottomWidth="1px"
+      gap={0}
+      position="fixed"
+      left={0}
+      right={0}
+      bottom={0}
+      zIndex={40}
+      px={2}
+      pt={2}
+      pb="calc(env(safe-area-inset-bottom) + 10px)"
+      borderTopWidth="1px"
       borderColor="cardBorder"
       bg="bg"
-      css={{
-        scrollbarWidth: 'thin',
-        WebkitOverflowScrolling: 'touch',
-      }}
+      display={{ base: 'flex', lg: 'none' }}
     >
       {ACCOUNT_NAV.map((item) => {
         const isActive = item.key === active
@@ -75,21 +169,25 @@ export function AccountTabStrip({ active }: AccountSideNavProps) {
             key={item.key}
             as={NextLink}
             href={item.href}
-            flexShrink={0}
-            px={3}
-            py={2}
-            borderRadius="full"
-            fontSize="sm"
-            fontWeight={isActive ? 700 : 600}
-            whiteSpace="nowrap"
-            bg={isActive ? 'primary' : 'cardBg'}
-            color={isActive ? 'black' : 'cardFg'}
-            borderWidth={isActive ? 0 : '1px'}
-            borderColor="cardBorder"
-            boxShadow={isActive ? 'sm' : 'none'}
-            _hover={{ textDecoration: 'none', opacity: 0.92 }}
+            flex={1}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            _hover={{ textDecoration: 'none' }}
           >
-            {item.label}
+            <Stack
+              gap={0.5}
+              align="center"
+              px={1}
+              py={1}
+              borderRadius="md"
+              color={isActive ? 'primary.700' : 'formLabelMuted'}
+            >
+              <NavIcon type={item.key} />
+              <Text fontSize="xs" fontWeight={isActive ? 700 : 600} lineHeight={1}>
+                {item.label}
+              </Text>
+            </Stack>
           </Link>
         )
       })}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -11,39 +11,70 @@ import {
   Text,
 } from '@chakra-ui/react'
 import NextLink from 'next/link'
+import { type ReactNode, useMemo } from 'react'
 
-import { Badge, Button, SectionCard } from '@ui'
+import { Button, SectionCard } from '@ui'
 
 import { useUserStore } from '@/app/(auth)/store/user'
-import { formatPounds, taskBudgetPence } from '@/utils/dashboardHelpers'
+import {
+  formatPounds,
+  isQuoteAwarded,
+  isTaskCompleted,
+  taskBudgetPence,
+  timeFromUnknown,
+} from '@/utils/dashboardHelpers'
+import { taskPublicLocationLabel } from '@/utils/taskLocationDisplay'
 
 import { useAccountTasks } from '../helpers/useAccountTasks'
 
-function StatTile({
-  label,
-  value,
-  helper,
-}: {
+type StatTileProps = {
   label: string
   value: string
   helper: string
-}) {
+  icon: ReactNode
+}
+
+type ActivityTone = 'green' | 'purple' | 'blue' | 'mint'
+
+type ActivityRow = {
+  id: string
+  title: string
+  subtitle: string
+  happenedAt: unknown
+  tone: ActivityTone
+}
+
+type MapPin = {
+  id: string
+  label: string
+  left: number
+  top: number
+}
+
+function StatTile({ label, value, helper, icon }: StatTileProps) {
   return (
     <SectionCard p={5}>
-      <Stack gap={1}>
-        <Text
-          fontSize="xs"
-          fontWeight={700}
-          letterSpacing="0.06em"
-          color="formLabelMuted"
-          textTransform="uppercase"
-        >
-          {label}
-        </Text>
-        <Heading size="lg" color="cardFg">
+      <Stack gap={2}>
+        <HStack justify="space-between" align="flex-start">
+          <Text fontSize="xs" fontWeight={700} color="formLabelMuted">
+            {label}
+          </Text>
+          <Box
+            w={9}
+            h={9}
+            borderRadius="full"
+            bg="primary.100"
+            color="primary.700"
+            display="grid"
+            placeItems="center"
+          >
+            {icon}
+          </Box>
+        </HStack>
+        <Heading size={{ base: 'md', md: 'lg' }} color="cardFg">
           {value}
         </Heading>
-        <Text fontSize="sm" color="formLabelMuted">
+        <Text fontSize="xs" color="formLabelMuted">
           {helper}
         </Text>
       </Stack>
@@ -51,17 +82,151 @@ function StatTile({
   )
 }
 
+function TileIcon({ type }: { type: 'posted' | 'quotes' | 'accepted' | 'done' }) {
+  if (type === 'posted') {
+    return (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <path
+          d="M7 4h10l3 3v13H4V4h3Zm10 0v3h3"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+  if (type === 'quotes') {
+    return (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <path
+          d="m5 12 5 5L20 7"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+  if (type === 'accepted') {
+    return (
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <path
+          d="M4 8h16v11H4V8Zm4-3h8v3H8V5Z"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="m8 12 2.7 2.7L16 9.4"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function ActivityIcon({ tone }: { tone: ActivityTone }) {
+  const bgByTone = {
+    green: 'green.100',
+    purple: 'purple.100',
+    blue: 'blue.100',
+    mint: 'primary.100',
+  } as const
+  const fgByTone = {
+    green: 'green.700',
+    purple: 'purple.700',
+    blue: 'blue.700',
+    mint: 'primary.700',
+  } as const
+  return (
+    <Box
+      w={8}
+      h={8}
+      borderRadius="full"
+      bg={bgByTone[tone]}
+      color={fgByTone[tone]}
+      display="grid"
+      placeItems="center"
+      fontSize="sm"
+      fontWeight={700}
+      flexShrink={0}
+    >
+      ·
+    </Box>
+  )
+}
+
+function ClockLabel({ happenedAt }: { happenedAt: unknown }) {
+  const timestamp = timeFromUnknown(happenedAt)
+  if (!timestamp) return <Text fontSize="xs" color="formLabelMuted">Recently</Text>
+  const diffMs = Date.now() - timestamp
+  const minute = 60 * 1000
+  const hour = 60 * minute
+  const day = 24 * hour
+  if (diffMs < hour) {
+    return (
+      <Text fontSize="xs" color="formLabelMuted">
+        {Math.max(1, Math.floor(diffMs / minute))}m ago
+      </Text>
+    )
+  }
+  if (diffMs < day) {
+    return (
+      <Text fontSize="xs" color="formLabelMuted">
+        {Math.floor(diffMs / hour)}h ago
+      </Text>
+    )
+  }
+  if (diffMs < day * 7) {
+    return (
+      <Text fontSize="xs" color="formLabelMuted">
+        {Math.floor(diffMs / day)}d ago
+      </Text>
+    )
+  }
+  return (
+    <Text fontSize="xs" color="formLabelMuted">
+      Earlier
+    </Text>
+  )
+}
+
+function QuickActionIcon({
+  kind,
+}: {
+  kind: 'post' | 'browse' | 'requests' | 'jobs' | 'profile'
+}) {
+  if (kind === 'browse') return <Text fontWeight={700}>⌕</Text>
+  if (kind === 'requests') return <Text fontWeight={700}>⌂</Text>
+  if (kind === 'jobs') return <Text fontWeight={700}>☑</Text>
+  if (kind === 'profile') return <Text fontWeight={700}>◯</Text>
+  return <Text fontWeight={700}>＋</Text>
+}
+
 export default function DashboardOverviewPage() {
   const me = useUserStore((s) => s.me)
   const {
     loading,
     errorMessage,
+    tasks,
+    postedTasks,
     activePostedTasks,
     sentQuotes,
-    customerJobs,
-    workerJobs,
     completedPostedTasks,
     awardedSentQuotes,
+    customerJobs,
+    workerJobs,
   } = useAccountTasks()
 
   const displayName =
@@ -70,27 +235,181 @@ export default function DashboardOverviewPage() {
     me?.email?.split('@')[0] ||
     'there'
 
+  const greeting =
+    new Date().getHours() < 12
+      ? 'Good morning'
+      : new Date().getHours() < 18
+        ? 'Good afternoon'
+        : 'Good evening'
+
+  const completedAsWorker = useMemo(
+    () =>
+      sentQuotes.filter(
+        ({ task, quote }) =>
+          isTaskCompleted(task.status) && isQuoteAwarded(quote.status),
+      ),
+    [sentQuotes],
+  )
+
+  const acceptedJobsCount = customerJobs.length + workerJobs.length
+  const completedJobsCount =
+    completedPostedTasks.length + completedAsWorker.length
   const totalEarningsPence = awardedSentQuotes.reduce(
     (sum, { quote }) => sum + (quote.price?.amount ?? 0) * 100,
     0,
   )
-  const totalSpendPence = completedPostedTasks.reduce(
-    (sum, task) => sum + taskBudgetPence(task),
-    0,
-  )
-  const isWorker = Boolean(me?.worker?.id)
+  const postedAwaitingQuotes = activePostedTasks.filter(
+    (task) => (task.quotes?.length ?? 0) === 0,
+  ).length
+  const quotesAwaitingResponse = sentQuotes.filter(
+    ({ quote }) => !isQuoteAwarded(quote.status),
+  ).length
+
+  const recentActivity = useMemo<ActivityRow[]>(() => {
+    const activity: ActivityRow[] = []
+    for (const task of postedTasks) {
+      activity.push({
+        id: `posted-${task.id}`,
+        title: 'Task posted',
+        subtitle: task.title,
+        happenedAt: task.createdAt,
+        tone: 'mint',
+      })
+      if (isTaskCompleted(task.status)) {
+        activity.push({
+          id: `completed-${task.id}`,
+          title: 'Job completed',
+          subtitle: task.title,
+          happenedAt: task.completedAt ?? task.confirmedAt ?? task.createdAt,
+          tone: 'green',
+        })
+      }
+    }
+
+    for (const { task, quote } of sentQuotes) {
+      activity.push({
+        id: `quote-sent-${quote.id}`,
+        title: 'You sent a quote',
+        subtitle: task.title,
+        happenedAt: quote.createdAt,
+        tone: 'purple',
+      })
+      if (isQuoteAwarded(quote.status)) {
+        activity.push({
+          id: `quote-awarded-${quote.id}`,
+          title: 'Quote accepted',
+          subtitle: task.title,
+          happenedAt: quote.createdAt,
+          tone: 'blue',
+        })
+      }
+    }
+
+    return activity
+      .sort(
+        (a, b) => timeFromUnknown(b.happenedAt) - timeFromUnknown(a.happenedAt),
+      )
+      .slice(0, 6)
+  }, [postedTasks, sentQuotes])
+
+  const mapPins = useMemo<MapPin[]>(() => {
+    const nearby = tasks
+      .filter(
+        (task) =>
+          typeof task.location?.lat === 'number' &&
+          typeof task.location?.lng === 'number',
+      )
+      .slice(0, 6)
+
+    if (nearby.length === 0) return []
+
+    const lats = nearby.map((task) => task.location?.lat as number)
+    const lngs = nearby.map((task) => task.location?.lng as number)
+    const minLat = Math.min(...lats)
+    const maxLat = Math.max(...lats)
+    const minLng = Math.min(...lngs)
+    const maxLng = Math.max(...lngs)
+    const latSpan = Math.max(0.0001, maxLat - minLat)
+    const lngSpan = Math.max(0.0001, maxLng - minLng)
+
+    return nearby.map((task) => {
+      const lat = task.location?.lat as number
+      const lng = task.location?.lng as number
+      return {
+        id: task.id,
+        label: formatPounds(taskBudgetPence(task)),
+        left: 14 + ((lng - minLng) / lngSpan) * 72,
+        top: 16 + (1 - (lat - minLat) / latSpan) * 66,
+      }
+    })
+  }, [tasks])
+
+  const quickActions = [
+    {
+      key: 'post',
+      title: 'Post a task',
+      subtitle: 'Get quotes from local workers',
+      href: '/tasks/create',
+      kind: 'post' as const,
+    },
+    {
+      key: 'browse',
+      title: 'Browse tasks',
+      subtitle: 'Find work and send quotes',
+      href: '/',
+      kind: 'browse' as const,
+    },
+    {
+      key: 'requests',
+      title: 'My requests',
+      subtitle: 'Track posted tasks and quotes',
+      href: '/requests',
+      kind: 'requests' as const,
+    },
+    {
+      key: 'jobs',
+      title: 'View jobs',
+      subtitle: 'Monitor accepted and active work',
+      href: '/jobs',
+      kind: 'jobs' as const,
+    },
+    {
+      key: 'profile',
+      title: 'Complete profile',
+      subtitle: me?.worker?.id
+        ? 'Keep your worker profile fresh'
+        : 'Set up your worker profile',
+      href: '/profile',
+      kind: 'profile' as const,
+    },
+  ]
+
+  const nearbyLabel =
+    (tasks[0] ? taskPublicLocationLabel(tasks[0]).trim() : '') ||
+    'Your local area'
 
   return (
-    <Stack gap={8}>
-      <Stack gap={2}>
-        <Heading size="xl" color="cardFg">
-          Welcome back, {displayName}.
-        </Heading>
-        <Text color="formLabelMuted" maxW="3xl">
-          One workspace for everything you do on Slashie — posted requests,
-          accepted jobs, earnings logs, and your worker profile.
-        </Text>
-      </Stack>
+    <Stack gap={{ base: 5, md: 6 }}>
+      <HStack justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+        <Stack gap={1}>
+          <Heading size="xl" color="cardFg">
+            {greeting}, {displayName}! <span aria-hidden>👋</span>
+          </Heading>
+          <Text color="formLabelMuted" maxW="3xl">
+            Manage your tasks, quotes and jobs in one place.
+          </Text>
+        </Stack>
+        <HStack gap={2} flexWrap="wrap">
+          <Link as={NextLink} href="/" _hover={{ textDecoration: 'none' }}>
+            <Button size="sm" variant="secondary">
+              Browse tasks
+            </Button>
+          </Link>
+          <Link as={NextLink} href="/tasks/create" _hover={{ textDecoration: 'none' }}>
+            <Button size="sm">Post task</Button>
+          </Link>
+        </HStack>
+      </HStack>
 
       {errorMessage ? (
         <Text color="red.500" fontSize="sm">
@@ -98,68 +417,92 @@ export default function DashboardOverviewPage() {
         </Text>
       ) : null}
 
-      <SimpleGrid columns={{ base: 1, md: 2, xl: 4 }} gap={4}>
+      <SimpleGrid columns={{ base: 2, xl: 4 }} gap={3}>
         <StatTile
-          label="Active requests"
-          value={loading ? '…' : String(activePostedTasks.length)}
-          helper="Tasks you posted that are still open or in progress."
+          label="Posted tasks"
+          value={loading ? '…' : String(postedTasks.length)}
+          helper={`${activePostedTasks.length} open · ${postedAwaitingQuotes} awaiting quotes`}
+          icon={<TileIcon type="posted" />}
         />
         <StatTile
           label="Quotes sent"
           value={loading ? '…' : String(sentQuotes.length)}
-          helper="Outbound quotes on tasks posted by other people."
+          helper={`${quotesAwaitingResponse} awaiting response`}
+          icon={<TileIcon type="quotes" />}
         />
         <StatTile
-          label="Active jobs"
-          value={
-            loading ? '…' : String(customerJobs.length + workerJobs.length)
-          }
-          helper="Tasks with an accepted quote — yours or someone else’s."
+          label="Accepted jobs"
+          value={loading ? '…' : String(acceptedJobsCount)}
+          helper="In progress across customer + worker roles"
+          icon={<TileIcon type="accepted" />}
         />
         <StatTile
-          label="Earnings tracked"
-          value={loading ? '…' : formatPounds(totalEarningsPence)}
-          helper="Awarded quote value. Slashie does not handle payouts."
+          label="Completed jobs"
+          value={loading ? '…' : String(completedJobsCount)}
+          helper={`Tracked earnings: ${formatPounds(totalEarningsPence)}`}
+          icon={<TileIcon type="done" />}
         />
       </SimpleGrid>
 
-      <Grid templateColumns={{ base: '1fr', xl: '1.4fr 1fr' }} gap={6}>
+      <Grid templateColumns={{ base: '1fr', xl: '1.3fr 1fr' }} gap={4}>
         <SectionCard p={{ base: 5, md: 6 }}>
-          <Stack gap={5}>
-            <Stack gap={1}>
-              <Heading size="md" color="cardFg">
-                Quick links
-              </Heading>
-              <Text fontSize="sm" color="formLabelMuted">
-                Jump back into the most common flows.
-              </Text>
-            </Stack>
-            <HStack gap={3} flexWrap="wrap">
-              <Link
-                as={NextLink}
-                href="/tasks/create"
-                _hover={{ textDecoration: 'none' }}
-              >
-                <Button>Post a task</Button>
-              </Link>
-              <Link as={NextLink} href="/" _hover={{ textDecoration: 'none' }}>
-                <Button variant="secondary">Browse open tasks</Button>
-              </Link>
+          <Stack gap={4}>
+            <HStack justify="space-between" gap={3}>
+              <Stack gap={1}>
+                <Heading size="md" color="cardFg">
+                  Recent activity
+                </Heading>
+                <Text fontSize="sm" color="formLabelMuted">
+                  Latest updates across your requests, jobs, and quotes.
+                </Text>
+              </Stack>
               <Link
                 as={NextLink}
                 href="/requests"
-                _hover={{ textDecoration: 'none' }}
+                fontSize="sm"
+                fontWeight={600}
+                color="primary.700"
+                _hover={{ textDecoration: 'none', color: 'primary.600' }}
               >
-                <Button variant="ghost">My requests</Button>
-              </Link>
-              <Link
-                as={NextLink}
-                href="/jobs"
-                _hover={{ textDecoration: 'none' }}
-              >
-                <Button variant="ghost">Jobs</Button>
+                View all
               </Link>
             </HStack>
+
+            {loading && recentActivity.length === 0 ? (
+              <Text color="formLabelMuted" fontSize="sm">
+                Loading activity…
+              </Text>
+            ) : recentActivity.length === 0 ? (
+              <Text color="formLabelMuted" fontSize="sm">
+                No activity yet. Start by posting a task or sending a quote.
+              </Text>
+            ) : (
+              <Stack gap={1}>
+                {recentActivity.map((item) => (
+                  <HStack
+                    key={item.id}
+                    justify="space-between"
+                    align="flex-start"
+                    py={2.5}
+                    borderBottomWidth="1px"
+                    borderColor="cardBorder"
+                  >
+                    <HStack align="flex-start" gap={3} minW={0}>
+                      <ActivityIcon tone={item.tone} />
+                      <Stack gap={0} minW={0}>
+                        <Text fontSize="sm" fontWeight={600} noOfLines={1}>
+                          {item.title}
+                        </Text>
+                        <Text fontSize="xs" color="formLabelMuted" noOfLines={1}>
+                          {item.subtitle}
+                        </Text>
+                      </Stack>
+                    </HStack>
+                    <ClockLabel happenedAt={item.happenedAt} />
+                  </HStack>
+                ))}
+              </Stack>
+            )}
           </Stack>
         </SectionCard>
 
@@ -167,42 +510,139 @@ export default function DashboardOverviewPage() {
           <Stack gap={4}>
             <HStack justify="space-between" align="flex-start">
               <Stack gap={1}>
-                <Heading size="md" color="cardFg">
-                  Worker status
-                </Heading>
+                <Heading size="md">Explore tasks near you</Heading>
                 <Text fontSize="sm" color="formLabelMuted">
-                  {isWorker
-                    ? 'Your worker profile is live — keep it fresh.'
-                    : 'Set up a worker profile when you’re ready to send quotes.'}
+                  Nearby opportunities from your account feed.
                 </Text>
               </Stack>
-              <Badge
-                bg={isWorker ? 'primary.100' : 'badgeBg'}
-                color={isWorker ? 'primary.800' : 'cardFg'}
-              >
-                {isWorker ? 'Active' : 'Not set up'}
-              </Badge>
-            </HStack>
-            <Box>
               <Link
                 as={NextLink}
-                href="/profile"
-                _hover={{ textDecoration: 'none' }}
+                href="/"
+                fontSize="sm"
+                fontWeight={600}
+                color="primary.700"
+                _hover={{ textDecoration: 'none', color: 'primary.600' }}
               >
-                <Button size="sm" variant={isWorker ? 'ghost' : 'primary'}>
-                  {isWorker ? 'Manage worker profile' : 'Become a worker'}
-                </Button>
+                View map
               </Link>
+            </HStack>
+
+            <Box
+              position="relative"
+              h={{ base: '180px', md: '220px' }}
+              borderRadius="xl"
+              overflow="hidden"
+              bg="linear-gradient(135deg, #f5f8f6 0%, #e8efec 100%)"
+            >
+              <Box
+                position="absolute"
+                inset={0}
+                opacity={0.45}
+                bgImage="repeating-linear-gradient(0deg, transparent, transparent 31px, rgba(255,255,255,0.7) 31px, rgba(255,255,255,0.7) 32px), repeating-linear-gradient(90deg, transparent, transparent 31px, rgba(255,255,255,0.7) 31px, rgba(255,255,255,0.7) 32px)"
+              />
+              <Box
+                position="absolute"
+                left="50%"
+                top="50%"
+                transform="translate(-50%, -50%)"
+                w="70px"
+                h="70px"
+                borderRadius="full"
+                bg="primary.100"
+                borderWidth="8px"
+                borderColor="primary.200"
+                opacity={0.9}
+              />
+              <Box
+                position="absolute"
+                left="50%"
+                top="50%"
+                transform="translate(-50%, -50%)"
+                w={4}
+                h={4}
+                borderRadius="full"
+                bg="blue.500"
+                borderWidth="2px"
+                borderColor="white"
+              />
+              {mapPins.map((pin) => (
+                <Box
+                  key={pin.id}
+                  position="absolute"
+                  left={`${pin.left}%`}
+                  top={`${pin.top}%`}
+                  transform="translate(-50%, -50%)"
+                  px={2}
+                  py={0.5}
+                  bg="primary.500"
+                  color="white"
+                  borderRadius="full"
+                  fontSize="xs"
+                  fontWeight={700}
+                  boxShadow="sm"
+                >
+                  {pin.label}
+                </Box>
+              ))}
             </Box>
-            <Stack gap={1}>
-              <Text fontSize="xs" color="formLabelMuted">
-                Lifetime spend on completed posts
+
+            <Stack gap={0.5}>
+              <Text fontSize="sm" fontWeight={600}>
+                {nearbyLabel}
               </Text>
-              <Text fontWeight={700}>{formatPounds(totalSpendPence)}</Text>
+              <Text fontSize="xs" color="formLabelMuted">
+                Approx. 5km radius
+              </Text>
             </Stack>
           </Stack>
         </SectionCard>
       </Grid>
+
+      <SectionCard p={{ base: 5, md: 6 }}>
+        <Stack gap={4}>
+          <Heading size="md">Quick actions</Heading>
+          <SimpleGrid columns={{ base: 1, sm: 2, xl: 5 }} gap={3}>
+            {quickActions.map((item) => (
+              <Link
+                key={item.key}
+                as={NextLink}
+                href={item.href}
+                _hover={{ textDecoration: 'none' }}
+              >
+                <Stack
+                  p={4}
+                  borderRadius="lg"
+                  bg="cardBg"
+                  borderWidth="1px"
+                  borderColor="cardBorder"
+                  minH="106px"
+                  justify="space-between"
+                >
+                  <HStack justify="space-between">
+                    <Text fontSize="sm" fontWeight={600}>
+                      {item.title}
+                    </Text>
+                    <Box
+                      w={8}
+                      h={8}
+                      borderRadius="full"
+                      bg="primary.100"
+                      color="primary.700"
+                      display="grid"
+                      placeItems="center"
+                    >
+                      <QuickActionIcon kind={item.kind} />
+                    </Box>
+                  </HStack>
+                  <Text fontSize="xs" color="formLabelMuted">
+                    {item.subtitle}
+                  </Text>
+                </Stack>
+              </Link>
+            ))}
+          </SimpleGrid>
+        </Stack>
+      </SectionCard>
     </Stack>
   )
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -82,10 +82,13 @@ function StatTile({ label, value, helper, icon }: StatTileProps) {
   )
 }
 
-function TileIcon({ type }: { type: 'posted' | 'quotes' | 'accepted' | 'done' }) {
+function TileIcon({
+  type,
+}: { type: 'posted' | 'quotes' | 'accepted' | 'done' }) {
   if (type === 'posted') {
     return (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <title>Posted tasks</title>
         <path
           d="M7 4h10l3 3v13H4V4h3Zm10 0v3h3"
           stroke="currentColor"
@@ -99,6 +102,7 @@ function TileIcon({ type }: { type: 'posted' | 'quotes' | 'accepted' | 'done' })
   if (type === 'quotes') {
     return (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <title>Quotes sent</title>
         <path
           d="m5 12 5 5L20 7"
           stroke="currentColor"
@@ -112,6 +116,7 @@ function TileIcon({ type }: { type: 'posted' | 'quotes' | 'accepted' | 'done' })
   if (type === 'accepted') {
     return (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+        <title>Accepted jobs</title>
         <path
           d="M4 8h16v11H4V8Zm4-3h8v3H8V5Z"
           stroke="currentColor"
@@ -124,6 +129,7 @@ function TileIcon({ type }: { type: 'posted' | 'quotes' | 'accepted' | 'done' })
   }
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <title>Completed jobs</title>
       <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
       <path
         d="m8 12 2.7 2.7L16 9.4"
@@ -169,7 +175,12 @@ function ActivityIcon({ tone }: { tone: ActivityTone }) {
 
 function ClockLabel({ happenedAt }: { happenedAt: unknown }) {
   const timestamp = timeFromUnknown(happenedAt)
-  if (!timestamp) return <Text fontSize="xs" color="formLabelMuted">Recently</Text>
+  if (!timestamp)
+    return (
+      <Text fontSize="xs" color="formLabelMuted">
+        Recently
+      </Text>
+    )
   const diffMs = Date.now() - timestamp
   const minute = 60 * 1000
   const hour = 60 * minute
@@ -390,7 +401,12 @@ export default function DashboardOverviewPage() {
 
   return (
     <Stack gap={{ base: 5, md: 6 }}>
-      <HStack justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+      <HStack
+        justify="space-between"
+        align="flex-start"
+        gap={4}
+        flexWrap="wrap"
+      >
         <Stack gap={1}>
           <Heading size="xl" color="cardFg">
             {greeting}, {displayName}! <span aria-hidden>👋</span>
@@ -405,7 +421,11 @@ export default function DashboardOverviewPage() {
               Browse tasks
             </Button>
           </Link>
-          <Link as={NextLink} href="/tasks/create" _hover={{ textDecoration: 'none' }}>
+          <Link
+            as={NextLink}
+            href="/tasks/create"
+            _hover={{ textDecoration: 'none' }}
+          >
             <Button size="sm">Post task</Button>
           </Link>
         </HStack>
@@ -490,10 +510,10 @@ export default function DashboardOverviewPage() {
                     <HStack align="flex-start" gap={3} minW={0}>
                       <ActivityIcon tone={item.tone} />
                       <Stack gap={0} minW={0}>
-                        <Text fontSize="sm" fontWeight={600} noOfLines={1}>
+                        <Text fontSize="sm" fontWeight={600} truncate>
                           {item.title}
                         </Text>
-                        <Text fontSize="xs" color="formLabelMuted" noOfLines={1}>
+                        <Text fontSize="xs" color="formLabelMuted" truncate>
                           {item.subtitle}
                         </Text>
                       </Stack>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rebuilt the `(dashboard)` account shell to match the approved unified dashboard structure with:
  - desktop left rail navigation (Overview, My Requests, Jobs, Earnings, Account, Profile)
  - in-dashboard header (search field, messages/notifications affordances, avatar/profile access)
  - mobile bottom navigation parity for the same six sections
- added profile completion and direct-payment disclaimer blocks into the dashboard shell sidebar
- redesigned `/dashboard` overview with:
  - greeting + primary actions
  - KPI stat cards for posted tasks, quotes sent, accepted jobs, and completed jobs
  - recent activity panel with derived account events
  - nearby tasks map-style preview block
  - quick actions row linking into core account workflows
- kept account data flow based on existing Zustand `me` snapshot + `myTasks` API query wiring

## Verification
- `npm run lint` ✅
- `npx tsc --noEmit` ⚠️ fails due existing repo baseline issues unrelated to this change:
  - missing `@codegen/schema` artifact in environment
  - pre-existing implicit `any` and downstream type errors in task detail/create flows

## Notes
- local environment does not have `bun` available, so validation was run via npm/npx equivalents
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-51](https://linear.app/slashie/issue/FE-51/rebuild-unified-account-hub-dashboard-from-approved-design)

<div><a href="https://cursor.com/agents/bc-1202954a-433c-44b0-9070-f6d1e4b1fba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1202954a-433c-44b0-9070-f6d1e4b1fba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

