### PR TITLE
FE-127: Unprefixed English URLs + marketing at /home with auth-aware /

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -55,89 +55,129 @@ const nextConfig: NextConfig = {
     ]
   },
   async redirects() {
-    const locale = ':locale(en|zh-hk)'
+    // Non-default locale keeps its slug; English destinations are unprefixed.
+    const zhHk = 'zh-hk'
     return [
       // Legacy browse surfaces merged into the unified map-first /search.
       // Exact-match only: /tasks/:slug and /workers/:slug stay untouched.
-      // Locale-prefixed variants keep the `/en` / `/zh-hk` slug.
       {
-        source: `/${locale}/tasks`,
-        destination: `/${locale}/search?mode=tasks`,
+        source: `/${zhHk}/tasks`,
+        destination: `/${zhHk}/search?mode=tasks`,
+        permanent: false,
+      },
+      {
+        source: '/en/tasks',
+        destination: '/search?mode=tasks',
         permanent: false,
       },
       {
         source: '/tasks',
-        destination: '/en/search?mode=tasks',
+        destination: '/search?mode=tasks',
         permanent: false,
       },
       {
-        source: `/${locale}/workers`,
-        destination: `/${locale}/search?mode=workers`,
+        source: `/${zhHk}/workers`,
+        destination: `/${zhHk}/search?mode=workers`,
+        permanent: false,
+      },
+      {
+        source: '/en/workers',
+        destination: '/search?mode=workers',
         permanent: false,
       },
       {
         source: '/workers',
-        destination: '/en/search?mode=workers',
+        destination: '/search?mode=workers',
         permanent: false,
       },
       {
-        source: `/${locale}/task/:slug`,
-        destination: `/${locale}/tasks/:slug`,
+        source: `/${zhHk}/task/:slug`,
+        destination: `/${zhHk}/tasks/:slug`,
+        permanent: true,
+      },
+      {
+        source: '/en/task/:slug',
+        destination: '/tasks/:slug',
         permanent: true,
       },
       {
         source: '/task/:slug',
-        destination: '/en/tasks/:slug',
+        destination: '/tasks/:slug',
         permanent: true,
       },
       {
-        source: `/${locale}/task/:slug/quote`,
-        destination: `/${locale}/tasks/:slug/quote`,
+        source: `/${zhHk}/task/:slug/quote`,
+        destination: `/${zhHk}/tasks/:slug/quote`,
+        permanent: true,
+      },
+      {
+        source: '/en/task/:slug/quote',
+        destination: '/tasks/:slug/quote',
         permanent: true,
       },
       {
         source: '/task/:slug/quote',
-        destination: '/en/tasks/:slug/quote',
+        destination: '/tasks/:slug/quote',
         permanent: true,
       },
       {
-        source: `/${locale}/requests/:id/order`,
-        destination: `/${locale}/tasks/:id#task-order`,
+        source: `/${zhHk}/requests/:id/order`,
+        destination: `/${zhHk}/tasks/:id#task-order`,
+        permanent: true,
+      },
+      {
+        source: '/en/requests/:id/order',
+        destination: '/tasks/:id#task-order',
         permanent: true,
       },
       {
         source: '/requests/:id/order',
-        destination: '/en/tasks/:id#task-order',
+        destination: '/tasks/:id#task-order',
         permanent: true,
       },
       {
-        source: `/${locale}/tasks/:slug/order`,
-        destination: `/${locale}/tasks/:slug#task-order`,
+        source: `/${zhHk}/tasks/:slug/order`,
+        destination: `/${zhHk}/tasks/:slug#task-order`,
+        permanent: true,
+      },
+      {
+        source: '/en/tasks/:slug/order',
+        destination: '/tasks/:slug#task-order',
         permanent: true,
       },
       {
         source: '/tasks/:slug/order',
-        destination: '/en/tasks/:slug#task-order',
+        destination: '/tasks/:slug#task-order',
         permanent: true,
       },
       {
-        source: `/${locale}/jobs`,
-        destination: `/${locale}/quotes`,
+        source: `/${zhHk}/jobs`,
+        destination: `/${zhHk}/quotes`,
+        permanent: true,
+      },
+      {
+        source: '/en/jobs',
+        destination: '/quotes',
         permanent: true,
       },
       {
         source: '/jobs',
-        destination: '/en/quotes',
+        destination: '/quotes',
         permanent: true,
       },
       {
-        source: `/${locale}/jobs/:path*`,
-        destination: `/${locale}/quotes/:path*`,
+        source: `/${zhHk}/jobs/:path*`,
+        destination: `/${zhHk}/quotes/:path*`,
+        permanent: true,
+      },
+      {
+        source: '/en/jobs/:path*',
+        destination: '/quotes/:path*',
         permanent: true,
       },
       {
         source: '/jobs/:path*',
-        destination: '/en/quotes/:path*',
+        destination: '/quotes/:path*',
         permanent: true,
       },
     ]

--- a/src/app/(auth)/forgot-password/components/ForgotPasswordForm.tsx
+++ b/src/app/(auth)/forgot-password/components/ForgotPasswordForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { MARKETING_HOME } from '@/utils/appRoutes'
 import { Box, Heading, Stack, Text } from '@chakra-ui/react'
 import { Button, FormField, Input, Link, Logo } from '@ui'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -59,7 +60,10 @@ export function ForgotPasswordForm() {
 
   return (
     <Stack gap={6} w="full">
-      <Link href="/" _hover={{ textDecoration: 'none', opacity: 0.92 }}>
+      <Link
+        href={MARKETING_HOME}
+        _hover={{ textDecoration: 'none', opacity: 0.92 }}
+      >
         <Logo h="48px" />
       </Link>
 
@@ -155,7 +159,7 @@ export function ForgotPasswordForm() {
       <Text fontSize="sm" color="text.muted" textAlign="center">
         Facing issues?{' '}
         <Link
-          href="/"
+          href={MARKETING_HOME}
           fontWeight={700}
           color="text.link"
           _hover={{ color: 'status.success.fg', textDecoration: 'none' }}

--- a/src/app/(auth)/forgot-password/components/ForgotPasswordSentPanel.tsx
+++ b/src/app/(auth)/forgot-password/components/ForgotPasswordSentPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { MARKETING_HOME } from '@/utils/appRoutes'
 import { Box, Heading, Stack, Text } from '@chakra-ui/react'
 import { Button, Link, Logo } from '@ui'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -65,7 +66,7 @@ export function ForgotPasswordSentPanel() {
   return (
     <Stack gap={6} w="full">
       <Link
-        href="/"
+        href={MARKETING_HOME}
         display="block"
         w="full"
         _hover={{ textDecoration: 'none', opacity: 0.92 }}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -25,7 +25,7 @@ import { useProgressiveCaptcha } from '@/app/(auth)/helpers/useProgressiveCaptch
 import { loginFormSchema } from '@/app/(auth)/login/loginFormSchema'
 import { useUserStore } from '@/app/(auth)/store/user'
 import { useI11n } from '@/i18n/useI11n'
-import { APP_HOME } from '@/utils/appRoutes'
+import { APP_HOME, MARKETING_HOME } from '@/utils/appRoutes'
 import { getAuthToken } from '@/utils/auth'
 import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
 import bag from './i11n.json'
@@ -436,7 +436,7 @@ export default function LoginPage() {
           >
             <Stack gap={6}>
               <Link
-                href="/"
+                href={MARKETING_HOME}
                 display="block"
                 w="full"
                 _hover={{ textDecoration: 'none', opacity: 0.92 }}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { MARKETING_HOME } from '@/utils/appRoutes'
 import { useMutation } from '@apollo/client/react'
 import { Box, Checkbox, HStack, Heading, Stack, Text } from '@chakra-ui/react'
 import type { RegisterMutation } from '@codegen/schema'
@@ -489,7 +490,7 @@ export default function RegisterPage() {
         >
           <Stack gap={6}>
             <Link
-              href="/"
+              href={MARKETING_HOME}
               display="block"
               w="full"
               _hover={{ textDecoration: 'none', opacity: 0.92 }}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { MARKETING_HOME } from '@/utils/appRoutes'
 import { useMutation } from '@apollo/client/react'
 import { Box, HStack, Heading, Stack, Text } from '@chakra-ui/react'
 import type { ResetPasswordMutation } from '@codegen/schema'
@@ -211,7 +212,7 @@ function MissingResetLinkState() {
   return (
     <Stack gap={6} w="full">
       <Link
-        href="/"
+        href={MARKETING_HOME}
         display="block"
         w="full"
         _hover={{ textDecoration: 'none', opacity: 0.92 }}
@@ -332,7 +333,7 @@ function ResetPasswordForm() {
   return (
     <Stack gap={6} w="full">
       <Link
-        href="/"
+        href={MARKETING_HOME}
         display="block"
         w="full"
         _hover={{ textDecoration: 'none', opacity: 0.92 }}

--- a/src/app/(auth)/verify-email/page.tsx
+++ b/src/app/(auth)/verify-email/page.tsx
@@ -16,7 +16,7 @@ import { useUserStore } from '@/app/(auth)/store/user'
 import VerifyEmail from '@/app/(auth)/verify-email/graphql/VerifyEmail.gql'
 import { useI11n } from '@/i18n/useI11n'
 import { EVENTS, trackFlowFailed, trackFlowSucceeded } from '@/utils/analytics'
-import { APP_HOME } from '@/utils/appRoutes'
+import { APP_HOME, MARKETING_HOME } from '@/utils/appRoutes'
 import { getAuthToken, setAuthToken } from '@/utils/auth'
 import { getFriendlyErrorMessage } from '@/utils/graphqlErrors'
 import bag from './i11n.json'
@@ -120,7 +120,7 @@ function VerifyEmailContent() {
   return (
     <Stack ref={onMountRef} gap={6} w="full">
       <Link
-        href="/"
+        href={MARKETING_HOME}
         display="block"
         w="full"
         _hover={{ textDecoration: 'none', opacity: 0.92 }}

--- a/src/app/(auth)/verify-email/sent/page.tsx
+++ b/src/app/(auth)/verify-email/sent/page.tsx
@@ -9,7 +9,7 @@ import { isEmailVerified } from '@/app/(auth)/helpers/emailVerification'
 import { useResendVerificationEmail } from '@/app/(auth)/helpers/useResendVerificationEmail'
 import { useMe } from '@/app/(auth)/store/user'
 import { useI11n } from '@/i18n/useI11n'
-import { APP_HOME } from '@/utils/appRoutes'
+import { APP_HOME, MARKETING_HOME } from '@/utils/appRoutes'
 import { getAuthToken } from '@/utils/auth'
 import bag from './i11n.json'
 
@@ -61,7 +61,7 @@ function VerifyEmailSentContent() {
   return (
     <Stack ref={onMountRef} gap={6} w="full">
       <Link
-        href="/"
+        href={MARKETING_HOME}
         display="block"
         w="full"
         _hover={{ textDecoration: 'none', opacity: 0.92 }}

--- a/src/app/(marketing)/components/MarketingHeader.tsx
+++ b/src/app/(marketing)/components/MarketingHeader.tsx
@@ -352,7 +352,7 @@ function MarketingNavigation({
 export type MarketingHeaderProps = Omit<BoxProps, 'children'>
 
 /**
- * Sticky marketing header. On the landing (`/`) it starts transparent over the
+ * Sticky marketing header. On the landing (`/home`) it starts transparent over the
  * dark WebGL hero with inverted text, then solidifies to the standard light
  * surface once scrolled. Other marketing routes (and no-JS visitors — the
  * overlay only engages after hydration) always get the solid header.

--- a/src/app/(marketing)/home/page.tsx
+++ b/src/app/(marketing)/home/page.tsx
@@ -11,18 +11,19 @@ import {
 } from '@/i18n/loadPageI11n'
 import { withLocale } from '@/i18n/navigation'
 import { Footer } from '@/ui'
+import { MARKETING_HOME } from '@/utils/appRoutes'
 
-import { LenisRoot } from './components/landing/LenisRoot'
-import { HeroSection } from './components/landing/hero/HeroSection'
-import { AudienceSection } from './components/landing/sections/AudienceSection'
-import { FinalCtaBand } from './components/landing/sections/FinalCtaBand'
-import { HowItWorks } from './components/landing/sections/HowItWorks'
+import { LenisRoot } from '../components/landing/LenisRoot'
+import { HeroSection } from '../components/landing/hero/HeroSection'
+import { AudienceSection } from '../components/landing/sections/AudienceSection'
+import { FinalCtaBand } from '../components/landing/sections/FinalCtaBand'
+import { HowItWorks } from '../components/landing/sections/HowItWorks'
 import {
   type LandingPricing,
   PricingTeaser,
-} from './components/landing/sections/PricingTeaser'
-import { TrustSection } from './components/landing/sections/TrustSection'
-import messages from './i11n.json'
+} from '../components/landing/sections/PricingTeaser'
+import { TrustSection } from '../components/landing/sections/TrustSection'
+import messages from '../i11n.json'
 
 export async function generateMetadata() {
   const locale = await getRequestLocale()
@@ -30,15 +31,15 @@ export async function generateMetadata() {
 
   return metadataFromI11n(copy.landing.metadata, {
     locale,
-    path: '/',
+    path: MARKETING_HOME,
   })
 }
 
 /**
- * Marketing landing. The narrative is fully server-rendered (SEO + no-JS
- * legible); the Spotlight + COBE globe hero and scroll motion are client
- * islands layered on top. Signed-in visitors stay on the landing (no
- * auto-redirect).
+ * Marketing landing at `/home`. The narrative is fully server-rendered
+ * (SEO + no-JS legible); the Spotlight + COBE globe hero and scroll motion
+ * are client islands layered on top. Root `/` auth-redirects guests here
+ * and signed-in users to `/search`.
  */
 export default async function MarketingHomePage() {
   const locale = await getRequestLocale()

--- a/src/app/(task)/search/components/SearchUrlSync.tsx
+++ b/src/app/(task)/search/components/SearchUrlSync.tsx
@@ -14,7 +14,7 @@ import { buildSearchUrl } from '../helpers/searchQueryParams'
 /**
  * Mirrors mode + viewport + submitted filters into the URL query
  * (history.replaceState — no navigation) so any /search view is shareable.
- * Keeps the active locale prefix so the locale proxy does not bounce `/search` → `/en/search`.
+ * Keeps the active locale in the URL (`/search` for en, `/zh-hk/search` for 繁中).
  */
 export function SearchUrlSync() {
   const locale = useLocale()

--- a/src/i18n/LocaleProvider.tsx
+++ b/src/i18n/LocaleProvider.tsx
@@ -8,7 +8,7 @@ import { localeFromPathname, withLocale } from '@/i18n/navigation'
 
 type LocaleContextValue = {
   locale: AppLocale
-  /** Prefix an internal href with the active locale. */
+  /** Localize an internal href for the active locale. */
   href: (path: string) => string
 }
 

--- a/src/i18n/loadPageI11n.ts
+++ b/src/i18n/loadPageI11n.ts
@@ -6,6 +6,7 @@ import {
   type I11nKey,
   LOCALE_TO_I11N_KEY,
 } from './locales'
+import { withLocale } from './navigation'
 
 export type PageI11nBag<T extends Record<string, unknown>> = {
   en: T
@@ -32,20 +33,20 @@ type MetadataFields = {
 /**
  * Build Next.js metadata from a page i11n bundle + canonical path
  * (path without locale prefix, e.g. `/pricing`).
+ * English canonicals omit `/en`; `zh-hk` keeps the slug.
  */
 export function metadataFromI11n(
   copy: MetadataFields,
   opts: {
     locale: AppLocale
-    /** Path without locale, e.g. `/` or `/pricing`. */
+    /** Path without locale, e.g. `/home` or `/pricing`. */
     path: string
     siteName?: string
   },
 ): Metadata {
   const title = copy.title ?? 'Slashie'
   const description = copy.description ?? ''
-  const localizedPath =
-    opts.path === '/' ? `/${opts.locale}` : `/${opts.locale}${opts.path}`
+  const localizedPath = withLocale(opts.locale, opts.path)
   const siteName = opts.siteName ?? 'Slashie'
 
   return {
@@ -54,8 +55,8 @@ export function metadataFromI11n(
     alternates: {
       canonical: localizedPath,
       languages: {
-        en: opts.path === '/' ? '/en' : `/en${opts.path}`,
-        'zh-HK': opts.path === '/' ? '/zh-hk' : `/zh-hk${opts.path}`,
+        en: withLocale('en', opts.path),
+        'zh-HK': withLocale('zh-hk', opts.path),
       },
     },
     openGraph: {

--- a/src/i18n/locales.test.ts
+++ b/src/i18n/locales.test.ts
@@ -27,14 +27,20 @@ describe('locales', () => {
 })
 
 describe('navigation', () => {
-  it('strips and prefixes locale slugs', () => {
+  it('strips locale slugs; default locale stays unprefixed', () => {
     expect(stripLocalePrefix('/en/pricing')).toBe('/pricing')
     expect(stripLocalePrefix('/zh-hk')).toBe('/')
+    expect(stripLocalePrefix('/home')).toBe('/home')
     expect(withLocale('zh-hk', '/pricing')).toBe('/zh-hk/pricing')
-    expect(withLocale('en', '/')).toBe('/en')
-    expect(withLocale('en', '/search?mode=tasks')).toBe('/en/search?mode=tasks')
+    expect(withLocale('zh-hk', '/home')).toBe('/zh-hk/home')
+    expect(withLocale('en', '/')).toBe('/')
+    expect(withLocale('en', '/home')).toBe('/home')
+    expect(withLocale('en', '/search?mode=tasks')).toBe('/search?mode=tasks')
     expect(localeFromPathname('/zh-hk/about')).toBe('zh-hk')
+    expect(localeFromPathname('/pricing')).toBe('en')
     expect(swapLocaleInPath('/en/pricing', 'zh-hk')).toBe('/zh-hk/pricing')
+    expect(swapLocaleInPath('/zh-hk/home', 'en')).toBe('/home')
+    expect(swapLocaleInPath('/home', 'zh-hk')).toBe('/zh-hk/home')
   })
 })
 

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -2,7 +2,7 @@ import { type AppLocale, DEFAULT_LOCALE, LOCALES, isAppLocale } from './locales'
 
 /**
  * Strip a leading locale segment from a pathname.
- * `/en/pricing` → `/pricing`; `/zh-hk` → `/`
+ * `/en/pricing` → `/pricing`; `/zh-hk` → `/`; `/pricing` → `/pricing`
  */
 export function stripLocalePrefix(pathname: string): string {
   const parts = pathname.split('/')
@@ -20,8 +20,9 @@ export function localeFromPathname(pathname: string): AppLocale {
 }
 
 /**
- * Prefix an internal href with the locale slug.
- * External URLs and hash-only links are returned unchanged.
+ * Localize an internal href for the active locale.
+ * Default locale (`en`) stays unprefixed (`/pricing`); non-default keeps a
+ * slug (`/zh-hk/pricing`). External URLs and hash-only links are unchanged.
  * Query strings and hashes are preserved.
  */
 export function withLocale(locale: AppLocale, href: string): string {
@@ -47,6 +48,11 @@ export function withLocale(locale: AppLocale, href: string): string {
   }
 
   const bare = stripLocalePrefix(path || '/')
+
+  if (locale === DEFAULT_LOCALE) {
+    return `${bare}${suffix}`
+  }
+
   const localized =
     bare === '/'
       ? `/${locale}`

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from 'next/server'
+import { describe, expect, it } from 'vitest'
+
+import { LOCALE_COOKIE, LOCALE_HEADER } from '@/i18n/locales'
+import { proxy } from '@/proxy'
+import { AUTH_COOKIE_NAME } from '@/utils/authCookie'
+
+function request(
+  path: string,
+  opts?: { cookie?: string; host?: string },
+): NextRequest {
+  const url = new URL(path, 'https://www.slashie.app')
+  const headers = new Headers()
+  if (opts?.host) headers.set('host', opts.host)
+  if (opts?.cookie) headers.set('cookie', opts.cookie)
+  return new NextRequest(url, { headers })
+}
+
+describe('proxy locale routing', () => {
+  it('redirects guest / to /home and preserves query', async () => {
+    const res = proxy(request('/?utm=1'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(
+      'https://www.slashie.app/home?utm=1',
+    )
+  })
+
+  it('redirects signed-in / to /search', () => {
+    const res = proxy(request('/', { cookie: `${AUTH_COOKIE_NAME}=token` }))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('https://www.slashie.app/search')
+  })
+
+  it('redirects /zh-hk guest to /zh-hk/home and signed-in to /zh-hk/search', () => {
+    const guest = proxy(request('/zh-hk'))
+    expect(guest.headers.get('location')).toBe(
+      'https://www.slashie.app/zh-hk/home',
+    )
+
+    const authed = proxy(
+      request('/zh-hk', { cookie: `${AUTH_COOKIE_NAME}=token` }),
+    )
+    expect(authed.headers.get('location')).toBe(
+      'https://www.slashie.app/zh-hk/search',
+    )
+  })
+
+  it('308-redirects /en/... to unprefixed paths', () => {
+    const res = proxy(request('/en/pricing?x=1'))
+    expect(res.status).toBe(308)
+    expect(res.headers.get('location')).toBe(
+      'https://www.slashie.app/pricing?x=1',
+    )
+
+    const root = proxy(request('/en'))
+    expect(root.status).toBe(308)
+    expect(root.headers.get('location')).toBe('https://www.slashie.app/')
+  })
+
+  it('serves bare English paths with en locale (no redirect)', () => {
+    const res = proxy(request('/search'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get(LOCALE_HEADER)).toBe('en')
+    expect(res.headers.get('set-cookie') ?? '').toContain(`${LOCALE_COOKIE}=en`)
+  })
+
+  it('rewrites /zh-hk/... and sets zh-hk locale', () => {
+    const res = proxy(request('/zh-hk/pricing'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get(LOCALE_HEADER)).toBe('zh-hk')
+    // rewrite: x-middleware-rewrite
+    const rewrite = res.headers.get('x-middleware-rewrite')
+    expect(rewrite).toContain('/pricing')
+  })
+
+  it('skips PostHog proxy host', () => {
+    const res = proxy(request('/e/', { host: 'e.slashie.app' }))
+    expect(res.status).toBe(200)
+    expect(res.headers.get(LOCALE_HEADER)).toBeNull()
+  })
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,14 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
 import {
+  type AppLocale,
   DEFAULT_LOCALE,
   LOCALE_COOKIE,
   LOCALE_HEADER,
   isAppLocale,
 } from '@/i18n/locales'
+import { APP_HOME, MARKETING_HOME } from '@/utils/appRoutes'
+import { AUTH_COOKIE_NAME } from '@/utils/authCookie'
 
 const PUBLIC_FILE = /\.[^/]+$/
 
@@ -30,10 +33,34 @@ function shouldSkip(pathname: string): boolean {
   return false
 }
 
+function hasAuthCookie(request: NextRequest): boolean {
+  const value = request.cookies.get(AUTH_COOKIE_NAME)?.value?.trim()
+  return Boolean(value)
+}
+
+/** Auth-aware entry destination (bare path, no locale slug). */
+function entryDestination(
+  request: NextRequest,
+): typeof APP_HOME | typeof MARKETING_HOME {
+  return hasAuthCookie(request) ? APP_HOME : MARKETING_HOME
+}
+
+function applyLocale(response: NextResponse, locale: AppLocale): NextResponse {
+  response.headers.set(LOCALE_HEADER, locale)
+  response.cookies.set(LOCALE_COOKIE, locale, {
+    path: '/',
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+  })
+  return response
+}
+
 /**
  * Locale slug routing (Next.js `proxy` — formerly `middleware`):
- * - `/en/...` and `/zh-hk/...` rewrite to the internal app path (no prefix).
- * - Paths without a locale redirect to `/en/...` (default).
+ * - Default locale (`en`) is unprefixed: `/search`, `/home`, …
+ * - Non-default (`zh-hk`) keeps `/zh-hk/...` and rewrites to the bare path.
+ * - Explicit `/en` and `/en/...` permanently redirect to the unprefixed path.
+ * - `/` and `/zh-hk` are auth-aware: signed-in → `/search`, guest → `/home`.
  */
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -56,25 +83,39 @@ export function proxy(request: NextRequest) {
     const restPath =
       restSegments.length === 0 ? '/' : `/${restSegments.join('/')}`
 
+    // Explicit `/en` / `/en/...` → permanent redirect to unprefixed path.
+    // `/` then applies the auth-aware entry redirect.
+    if (maybeLocale === DEFAULT_LOCALE) {
+      const redirectUrl = request.nextUrl.clone()
+      redirectUrl.pathname = restPath
+      return NextResponse.redirect(redirectUrl, 308)
+    }
+
+    // Locale root `/zh-hk` → auth-aware entry under that locale.
+    if (restPath === '/') {
+      const dest = entryDestination(request)
+      const redirectUrl = request.nextUrl.clone()
+      redirectUrl.pathname = `/${maybeLocale}${dest}`
+      return NextResponse.redirect(redirectUrl)
+    }
+
     const rewriteUrl = request.nextUrl.clone()
     rewriteUrl.pathname = restPath
 
     const response = NextResponse.rewrite(rewriteUrl)
-    response.headers.set(LOCALE_HEADER, maybeLocale)
-    response.cookies.set(LOCALE_COOKIE, maybeLocale, {
-      path: '/',
-      maxAge: 60 * 60 * 24 * 365,
-      sameSite: 'lax',
-    })
-    return response
+    return applyLocale(response, maybeLocale)
   }
 
-  // No locale slug → redirect to default `en` (keep query string).
-  const locale = DEFAULT_LOCALE
-  const redirectUrl = request.nextUrl.clone()
-  redirectUrl.pathname =
-    pathname === '/' ? `/${locale}` : `/${locale}${pathname}`
-  return NextResponse.redirect(redirectUrl)
+  // Bare `/` → auth-aware English entry (preserve query string).
+  if (pathname === '/') {
+    const redirectUrl = request.nextUrl.clone()
+    redirectUrl.pathname = entryDestination(request)
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  // Unprefixed English path — set locale and continue (no redirect to `/en`).
+  const response = NextResponse.next()
+  return applyLocale(response, DEFAULT_LOCALE)
 }
 
 export const config = {

--- a/src/ui/Link/Link.tsx
+++ b/src/ui/Link/Link.tsx
@@ -15,10 +15,10 @@ import { sdlFocusRing, sdlMotion } from '@/theme/styles'
  * SDL inline Link. Renders the SDL link role (`text.link`, green-700 in light /
  * green-300 in dark) and uses Next.js client navigation for internal `href`s.
  *
- * Internal string `href`s are prefixed with the active locale automatically
- * (`/tasks` → `/en/tasks`). External URLs, `mailto:`, `tel:`, and hash-only
- * links are left unchanged. Call sites should pass bare paths — do not wrap
- * with `useLocalizedHref()`.
+ * Internal string `href`s are localized automatically: default locale (`en`)
+ * stays unprefixed (`/tasks`); `zh-hk` gets `/zh-hk/tasks`. External URLs,
+ * `mailto:`, `tel:`, and hash-only links are left unchanged. Call sites
+ * should pass bare paths — do not wrap with `useLocalizedHref()`.
  *
  * Tones:
  * - `default` — standard inline link (`text.link`), underline on hover.

--- a/src/utils/accountNav.ts
+++ b/src/utils/accountNav.ts
@@ -3,7 +3,7 @@
  *
  * Routes here are URL-unprefixed because `(dashboard)` is a Next route group,
  * not a URL segment. Overview owns `/dashboard`; everything else is a sibling.
- * Locale slugs (`/en`, `/zh-hk`) are stripped before matching.
+ * Locale slugs (`/zh-hk`, legacy `/en`) are stripped before matching.
  */
 
 import { stripLocalePrefix } from '@/i18n/navigation'

--- a/src/utils/appRoutes.ts
+++ b/src/utils/appRoutes.ts
@@ -5,7 +5,7 @@ export const APP_HOME = '/search' as const
 export const WORKER_SEARCH_HREF = '/search?mode=workers' as const
 
 /** Public marketing entry. */
-export const MARKETING_HOME = '/' as const
+export const MARKETING_HOME = '/home' as const
 
 /** Marketing / store landing until dedicated app-store links exist. */
 export const GET_APP_HREF = 'https://slashie.app' as const

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,8 @@
 'use client'
 
-export const AUTH_COOKIE_NAME = 'auth'
+import { AUTH_COOKIE_NAME } from '@/utils/authCookie'
+
+export { AUTH_COOKIE_NAME }
 
 function decodeCookieValue(value: string) {
   try {

--- a/src/utils/authCookie.ts
+++ b/src/utils/authCookie.ts
@@ -1,0 +1,2 @@
+/** Session cookie name — safe to import from proxy / server code. */
+export const AUTH_COOKIE_NAME = 'auth'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [FE-127](https://linear.app/slashie/issue/FE-127/default-locale-unprefixed-urls-move-marketing-to-home-with-auth-aware): default locale (`en`) is no longer URL-prefixed, marketing moves to `/home`, and `/` becomes an auth-aware entry redirect.

### Behavior

| Request | Result |
|---|---|
| `/search`, `/pricing`, `/home`, … | Served as English (no bounce to `/en`) |
| `/zh-hk/...` | Rewrite to bare path + `zh-hk` locale (unchanged) |
| `/en`, `/en/...` | **308** → unprefixed `/`, `/...` |
| `/` guest | → `/home` |
| `/` with `auth` cookie | → `/search` |
| `/zh-hk` guest / signed-in | → `/zh-hk/home` / `/zh-hk/search` |
| `e.slashie.app` | Skips locale routing (unchanged) |

### Code

- `src/proxy.ts` — unprefixed `en`, `/en` strip, auth-aware `/` + `/zh-hk`
- `withLocale` / `swapLocaleInPath` — bare English hrefs; `zh-hk` stays prefixed
- `MARKETING_HOME` → `/home`; marketing page moved to `src/app/(marketing)/home/`
- `metadataFromI11n` — English canonicals omit `/en`
- `next.config.ts` — legacy redirects target bare English paths
- Auth logo links → `MARKETING_HOME`
- Unit tests: `src/proxy.test.ts` + updated `locales.test.ts`

### Verify

- `bun run lint`
- `bun run test:unit src/proxy.test.ts src/i18n/locales.test.ts` (22 passed)
- `tsc --noEmit` on changed files clean (full tree needs `.codegen/schema.ts`)

Closes FE-127.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-127](https://linear.app/slashie/issue/FE-127/default-locale-unprefixed-urls-move-marketing-to-home-with-auth-aware)

<div><a href="https://cursor.com/agents/bc-12ff7c2e-cf04-475f-957d-2f18e07e79b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12ff7c2e-cf04-475f-957d-2f18e07e79b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

