### PR TITLE
feat(auth): Immich-style /api/auth/mobile-redirect for Expo Google OAuth (FE-128)

### DIFF
--- a/src/app/api/auth/mobile-redirect/mobileRedirect.test.ts
+++ b/src/app/api/auth/mobile-redirect/mobileRedirect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MOBILE_OAUTH_CALLBACK,
+  buildMobileDeepLink,
+  buildMobileRedirectHtml,
+  escapeHtmlAttr,
+} from './mobileRedirect'
+
+describe('buildMobileDeepLink', () => {
+  it('appends query string to slashie://oauth-callback', () => {
+    expect(buildMobileDeepLink('?code=test&state=abc')).toBe(
+      `${MOBILE_OAUTH_CALLBACK}?code=test&state=abc`,
+    )
+  })
+
+  it('accepts search without leading ?', () => {
+    expect(buildMobileDeepLink('code=test&state=abc')).toBe(
+      `${MOBILE_OAUTH_CALLBACK}?code=test&state=abc`,
+    )
+  })
+
+  it('preserves hash when provided', () => {
+    expect(buildMobileDeepLink('?code=1', '#frag')).toBe(
+      `${MOBILE_OAUTH_CALLBACK}?code=1#frag`,
+    )
+    expect(buildMobileDeepLink('?code=1', 'frag')).toBe(
+      `${MOBILE_OAUTH_CALLBACK}?code=1#frag`,
+    )
+  })
+
+  it('works with empty query', () => {
+    expect(buildMobileDeepLink('')).toBe(MOBILE_OAUTH_CALLBACK)
+  })
+})
+
+describe('escapeHtmlAttr', () => {
+  it('escapes characters unsafe in double-quoted attributes', () => {
+    expect(escapeHtmlAttr(`a&b"c<'>`)).toBe('a&amp;b&quot;c&lt;&#39;&gt;')
+  })
+})
+
+describe('buildMobileRedirectHtml', () => {
+  it('embeds deep link and Open Slashie fallback for oauth params', () => {
+    const html = buildMobileRedirectHtml('?code=test&state=abc')
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain(MOBILE_OAUTH_CALLBACK)
+    expect(html).toContain('?code=test&amp;state=abc')
+    expect(html).toContain('Open Slashie')
+    expect(html).toContain('window.location.replace')
+    expect(html).toContain('window.location.search')
+    expect(html).toContain('window.location.hash')
+  })
+
+  it('escapes query values that could break attributes', () => {
+    const html = buildMobileRedirectHtml('?x="><script>alert(1)</script>')
+    expect(html).not.toContain('href="?x="><script>')
+    expect(html).toContain('&quot;')
+    expect(html).toContain('&lt;script&gt;')
+  })
+})

--- a/src/app/api/auth/mobile-redirect/mobileRedirect.ts
+++ b/src/app/api/auth/mobile-redirect/mobileRedirect.ts
@@ -1,0 +1,72 @@
+/**
+ * Immich-style HTTPS → custom-scheme bridge for Expo Google OAuth.
+ *
+ * Google Web clients reject custom-scheme redirect URIs, so Google redirects
+ * here (`https://slashie.app/api/auth/mobile-redirect`) and this page forwards
+ * into the app deep link `slashie://oauth-callback` while preserving query
+ * (and hash on the client, which the server never receives).
+ *
+ * Prefer HTML + JS over a bare 307: Android Chrome / WebView often hang on
+ * HTTP redirects to custom schemes (see Immich #24409).
+ */
+
+/** Expo `app.json` scheme — deep link target for OAuth callback. */
+export const MOBILE_OAUTH_CALLBACK = 'slashie://oauth-callback'
+
+export function buildMobileDeepLink(search: string, hash = ''): string {
+  const query = search.startsWith('?') ? search : search ? `?${search}` : ''
+  const fragment = hash.startsWith('#') ? hash : hash ? `#${hash}` : ''
+  return `${MOBILE_OAUTH_CALLBACK}${query}${fragment}`
+}
+
+/** Escape a value for use inside a double-quoted HTML attribute. */
+export function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * HTML bridge page: JS sets `window.location` to the deep link (query + hash
+ * from the browser URL). Fallback anchor uses the server-built query href;
+ * JS upgrades it when a hash is present.
+ */
+export function buildMobileRedirectHtml(search: string): string {
+  const deepLink = buildMobileDeepLink(search)
+  const hrefAttr = escapeHtmlAttr(deepLink)
+  // JSON.stringify yields a JS string literal safe for embedding in <script>.
+  const callbackLiteral = JSON.stringify(MOBILE_OAUTH_CALLBACK)
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>Opening Slashie…</title>
+  <script>
+    (function () {
+      var qs = window.location.search || "";
+      var hash = window.location.hash || "";
+      var target = ${callbackLiteral} + qs + hash;
+      window.location.replace(target);
+    })();
+  </script>
+</head>
+<body>
+  <p>Opening Slashie…</p>
+  <p>If nothing happens, <a id="slashie-open" href="${hrefAttr}">Open Slashie</a>.</p>
+  <script>
+    (function () {
+      var qs = window.location.search || "";
+      var hash = window.location.hash || "";
+      var el = document.getElementById("slashie-open");
+      if (el) el.href = ${callbackLiteral} + qs + hash;
+    })();
+  </script>
+</body>
+</html>`
+}

--- a/src/app/api/auth/mobile-redirect/route.ts
+++ b/src/app/api/auth/mobile-redirect/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+
+import { buildMobileRedirectHtml } from './mobileRedirect'
+
+/**
+ * GET /api/auth/mobile-redirect
+ *
+ * Pure redirect bridge for Expo Google OAuth. Does not create sessions or
+ * set Slashie auth cookies. Whitelisted in Google Cloud Console as:
+ *   https://slashie.app/api/auth/mobile-redirect
+ * (also add www if that host is live without apex rewrite)
+ */
+export function GET(request: Request): NextResponse {
+  const { search } = new URL(request.url)
+  const html = buildMobileRedirectHtml(search)
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      // Explicitly avoid accidental cookie/session side effects on this bridge.
+      'Referrer-Policy': 'no-referrer',
+    },
+  })
+}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -78,4 +78,11 @@ describe('proxy locale routing', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get(LOCALE_HEADER)).toBeNull()
   })
+
+  it('skips /api auth mobile-redirect (no locale cookie rewrite)', () => {
+    const res = proxy(request('/api/auth/mobile-redirect?code=test&state=abc'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get(LOCALE_HEADER)).toBeNull()
+    expect(res.headers.get('set-cookie')).toBeNull()
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `GET /api/auth/mobile-redirect` as an Immich-style HTTPS → custom-scheme bridge so Google Web OAuth clients can redirect into the Expo app.

Google rejects custom-scheme redirect URIs. After consent, Google hits `https://slashie.app/api/auth/mobile-redirect?<oauth-params>`, and this route returns an HTML+JS page that navigates to `slashie://oauth-callback?<oauth-params>` (query preserved; hash preserved client-side). Includes a visible **Open Slashie** fallback link.

Resolves [FE-128](https://linear.app/slashie/issue/FE-128/web-immich-style-apiauthmobile-redirect-bridge-for-expo-google-oauth). Unblocks Expo follow-up [FE-129](https://linear.app/slashie/issue/FE-129).

## Operator note (Google Cloud Console)

Authorized redirect URIs on the **Google Web client** must include:

- `https://slashie.app/api/auth/mobile-redirect`
- `https://www.slashie.app/api/auth/mobile-redirect` (only if `www` is a live host without apex rewrite)

Reporter already added the apex URI.

## Implementation

- `src/app/api/auth/mobile-redirect/route.ts` — `GET` returns HTML (not a bare 307; Android Chrome often hangs on 307→custom-scheme)
- Pure bridge: no auth cookies / sessions / Apollo
- `src/proxy.ts` already skips `/api/**` (locale middleware does not rewrite this path)
- Unit tests for deep-link construction + HTML escaping; proxy skip coverage

## Test plan

- [x] `bun run lint`
- [x] `bunx tsc --noEmit` (no `typecheck` script in package.json)
- [x] Unit tests for deep link + HTML bridge
- [x] Local smoke: `/api/auth/mobile-redirect?code=test&state=abc` → 200 HTML, fallback href `slashie://oauth-callback?code=test&state=abc`, no `Set-Cookie`
- [ ] On a device with Slashie installed, open the HTTPS URL and confirm OS offers/opens the app
- [ ] Confirm web GIS Google login on `/login` is unchanged
- [ ] Re-check on Vercel preview / production after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FE-128](https://linear.app/slashie/issue/FE-128/web-immich-style-apiauthmobile-redirect-bridge-for-expo-google-oauth)

<div><a href="https://cursor.com/agents/bc-093c1d8c-c508-4a72-91af-f5e117fb66ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-093c1d8c-c508-4a72-91af-f5e117fb66ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

